### PR TITLE
Use event-config.h from event2/

### DIFF
--- a/src/evhttp/http.c
+++ b/src/evhttp/http.c
@@ -25,7 +25,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <event-config.h>
+#include <event2/event-config.h>
 
 #ifdef _EVENT_HAVE_SYS_PARAM_H
 #include <sys/param.h>

--- a/src/evrtsp/rtsp.c
+++ b/src/evrtsp/rtsp.c
@@ -28,7 +28,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <event-config.h>
+#include <event2/event-config.h>
 
 #ifdef _EVENT_HAVE_SYS_PARAM_H
 #include <sys/param.h>


### PR DESCRIPTION
This fixes compilation on Debian Wheezy and I think it should work on other systems as well.

Could you please make a tag which is is higher than 0.19gcd? I would like to revive the Debian package using your repository as upstream.
