### PR TITLE
Use EVBUFFER_EOL_CRLF for evbuffer_readln

### DIFF
--- a/src/evrtsp/rtsp.c
+++ b/src/evrtsp/rtsp.c
@@ -1075,7 +1075,7 @@ evrtsp_parse_headers(struct evrtsp_request *req, struct evbuffer *buffer)
 	enum message_read_status status = MORE_DATA_EXPECTED;
 
 	struct evkeyvalq *headers = req->input_headers;
-	while ((line = evbuffer_readln(buffer, NULL, EVBUFFER_EOL_ANY))
+	while ((line = evbuffer_readln(buffer, NULL, EVBUFFER_EOL_CRLF))
 	       != NULL) {
 		char *skey, *svalue;
 


### PR DESCRIPTION
This is the pull request for #6

Due to the use of EVBUFFER_EOL_ANY in evbuffer_readln the end of the rtsp header is not recognized (EVBUFFER_EOL_ANY does not return empty lines).  Changing it to EVBUFFER_EOL_CRLF makes sure that the end of the rtsp header is recognized.
