### PR TITLE
discussion: improve performance of bulk scan

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -309,7 +309,10 @@ void
 free_pli(struct playlist_info *pli, int content_only);
 
 /* Maintenance and DB hygiene */
-void
+int
+db_hook_pre_scan(void);
+
+int
 db_hook_post_scan(void);
 
 void


### PR DESCRIPTION
Just read this - http://stackoverflow.com/questions/1711631/how-do-i-improve-the-performance-of-sqlite - about sqlite3 performance. The changes are a proof of concept. On my ubuntu machine the scan performance on startup without this change is ~5 seconds, with this change its not measurable (at least with the simple logging i added).

@ejurgensen is this something you want? I haven't looked close into the scanner code, so if you want, you can take over ...
