### PR TITLE
Fix crash when calling add-next and cur_playing/cur_streaming are NULL

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -3429,9 +3429,9 @@ queue_add_next(struct player_command *cmd)
   if (!ps_shuffle)
     ps_shuffle = ps;
 
-  if (source_head)
+  if (source_head && cur_streaming)
   {
-    ps_playing = cur_playing ? cur_playing : cur_streaming;
+    ps_playing = cur_streaming;
 
     // Insert ps after ps_playing
     ps->pl_prev->pl_next = ps_playing->pl_next;


### PR DESCRIPTION
In my addition of  "queue_add_next" i introduced a crash if cur_playing and cur_streaming are NULL and source_head is not. I can produce this situation by pressing skip next, while the last song of the queue is playing. Playback stops and cur_streaming/cur_playing are NULL while source_head is still set.

As i understand the code now, the new songs should be added after cur_streaming. Adding them after cur_playing may introduce issues if cur_streaming already points to the next song of the queue and therefor data packets were already send to the speakers (this should be the case in the last two seconds of the playing song).
