### PR TITLE
Improve support for "play next" and "add to up next" with Retune

### DIFF
--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1418,13 +1418,14 @@ dacp_reply_playqueueedit_add(struct evhttp_request *req, struct evbuffer *evbuf,
 	sort = "album";
       }
 
-      queuefilter = evhttp_find_header(query, "queuefilter");
+      // only use queryfilter if mode is not equal 3 (play next) or 5 (add to up next)
+      queuefilter = (mode == 3 || mode == 5) ? NULL : evhttp_find_header(query, "queuefilter");
 
       querymodifier = evhttp_find_header(query, "query-modifier");
       if (!querymodifier || (strcmp(querymodifier, "containers") != 0))
 	{
 	  quirkyquery = (mode == 1) && strstr(editquery, "dmap.itemid:") && ((!queuefilter) || strstr(queuefilter, "(null)"));
-	  ret = player_queue_make_daap(&ps, editquery, queuefilter, sort, quirkyquery);  
+	  ret = player_queue_make_daap(&ps, editquery, queuefilter, sort, quirkyquery);
 	}
       else
 	{


### PR DESCRIPTION
I noticed that adding songs to UpNext does not work as expected using Retune for Android. Compared with Remote, Retune sends slightly different requests for /ctrl-int/1/playqueue-edit?command=add. The requests from Retune contain a queryfilter and are using mode=5 for "add to up next".

The result in forked-daapd is, that adding albums fails due to an unkown queryfilter and adding a song results in adding the whole album.

This pr solves this by ignoring the queryfilter if mode equals 3 or 5.

Following are example requests from Retune and Remote for the different actions:

---

play next (mode=3)

artist
RETUNE  query='daap.songartistid:8737690491750445895'&mode=3&sort=album
REMOTE  query='daap.songartistid:8737690491750445895'&mode=3

album
RETUNE  query='daap.songalbumid:2508798002402331394'&queuefilter=daap.songartistid:daap.songartistid&mode=3&sort=album
REMOTE  query='daap.songalbumid:2508798002402331394'&mode=3

song
RETUNE  query='dmap.itemid:267'&queuefilter=album:2962730986270837555&mode=3&sort=album
REMOTE  query='dmap.itemid:214'&sort=album&mode=3

---

add to up next (mode=0 or 5)

artist
RETUNE  query='daap.songartistid:8395563705718003786'&mode=5&sort=album
REMOTE  query='daap.songartistid:8395563705718003786'&mode=0

album
RETUNE  query='daap.songalbumid:1097405317079198826'&queuefilter=daap.songartistid:daap.songartistid&mode=5&sort=album
REMOTE  query='daap.songalbumid:5051836678885201954'&mode=0&session-id=101

song
RETUNE  query='dmap.itemid:214'&queuefilter=album:6163486401813019511&mode=5&sort=album
REMOTE  query='dmap.itemid:214'&sort=album&mode=0&session-id=101

---

start playback (mode=1)

artist
RETUNE  query='daap.songartistid:8737690491750445895'&mode=1&sort=album&clear-previous=1
REMOTE  (does not have this functionality)

album
RETUNE  query='daap.songalbumid:7735296599549371307'&queuefilter=daap.songartistid:daap.songartistid&mode=1&sort=album&clear-previous=1
REMOTE (does not have this functionality)

song
RETUNE  query='dmap.itemid:266'&queuefilter=album:2962730986270837555&mode=1&sort=album&clear-previous=1
REMOTE  query='dmap.itemid:214'&queuefilter=artist:8395563705718003786&sort=album&mode=1
