### PR TITLE
Modifications to the playqueue-clear command

### DIFF
--- a/src/player.h
+++ b/src/player.h
@@ -174,6 +174,9 @@ void
 player_queue_clear(void);
 
 void
+player_queue_empty(int clear_hist);
+
+void
 player_queue_plid(uint32_t plid);
 
 struct player_history *


### PR DESCRIPTION
This pr modifies the handling of the playqueue-clear command to be more in line with iTunes. If the "mode" parameter in the request equals 0x68697374 ("hist" in ascii), forked-daapd clears the history instead of always clearing the Up Next queue. Furthermore the clear command will not stop playback, instead the playqueue is modified, so that all elements are removed except the current song. There is one special case: in the last two seconds of a song the streaming and playing song are not the same. In this case the clear command stops playback and clears the whole playqueue (like the behavior without this pr).

I made another modification in the playqueue-contents command, so that it returns the history, even if playback is stopped.

I haven't found out when "cue?command=clear" request are send from the remote, thats the reason why i didn't modify the existing functions and added new ones. Maybe this is not necessary? 
