### PR TITLE
Added options to modify the SQLite cache size, synchronous flag and journal mode

### DIFF
--- a/src/conffile.c
+++ b/src/conffile.c
@@ -48,6 +48,9 @@ static cfg_opt_t sec_general[] =
     CFG_STR("admin_password", NULL, CFGF_NONE),
     CFG_STR("logfile", STATEDIR "/log/" PACKAGE ".log", CFGF_NONE),
     CFG_STR("db_path", STATEDIR "/cache/" PACKAGE "/songs3.db", CFGF_NONE),
+    CFG_INT("db_pragma_cache_size", -1, CFGF_NONE),
+    CFG_STR("db_pragma_journal_mode", NULL, CFGF_NONE),
+    CFG_INT("db_pragma_synchronous", -1, CFGF_NONE),
     CFG_INT_CB("loglevel", E_LOG, CFGF_NONE, &cb_loglevel),
     CFG_BOOL("ipv6", cfg_false, CFGF_NONE),
     CFG_END()

--- a/src/db.c
+++ b/src/db.c
@@ -4338,12 +4338,182 @@ db_xprofile(void *notused, const char *pquery, sqlite3_uint64 ptime)
 }
 #endif
 
+static int
+db_pragma_get_cache_size()
+{
+  sqlite3_stmt *stmt;
+  char *query = "PRAGMA cache_size;";
+  int ret;
+
+  DPRINTF(E_DBG, L_DB, "Running query '%s'\n", query);
+
+  ret = db_blocking_prepare_v2(query, -1, &stmt, NULL);
+  if (ret != SQLITE_OK)
+    {
+      DPRINTF(E_LOG, L_DB, "Could not prepare statement: %s\n", sqlite3_errmsg(hdl));
+
+      sqlite3_free(query);
+      return 0;
+    }
+
+  ret = db_blocking_step(stmt);
+  if (ret == SQLITE_DONE)
+    {
+      DPRINTF(E_DBG, L_DB, "End of query results\n");
+      sqlite3_free(query);
+      return 0;
+    }
+  else if (ret != SQLITE_ROW)
+    {
+      DPRINTF(E_LOG, L_DB, "Could not step: %s\n", sqlite3_errmsg(hdl));
+      sqlite3_free(query);
+      return -1;
+    }
+
+  ret = sqlite3_column_int(stmt, 0);
+
+  sqlite3_finalize(stmt);
+  return ret;
+}
+
+static int
+db_pragma_set_cache_size(int pages)
+{
+#define Q_TMPL "PRAGMA cache_size=%d;"
+  sqlite3_stmt *stmt;
+  char *query;
+  int ret;
+
+  query = sqlite3_mprintf(Q_TMPL, pages);
+  DPRINTF(E_DBG, L_DB, "Running query '%s'\n", query);
+
+  ret = db_blocking_prepare_v2(query, -1, &stmt, NULL);
+  if (ret != SQLITE_OK)
+    {
+      DPRINTF(E_LOG, L_DB, "Could not prepare statement: %s\n", sqlite3_errmsg(hdl));
+
+      sqlite3_free(query);
+      return 0;
+    }
+
+  sqlite3_finalize(stmt);
+  sqlite3_free(query);
+  return 0;
+}
+
+static char *
+db_pragma_set_journal_mode(char *mode)
+{
+#define Q_TMPL "PRAGMA journal_mode=%s;"
+  sqlite3_stmt *stmt;
+  char *query;
+  int ret;
+  char *new_mode;
+
+  query = sqlite3_mprintf(Q_TMPL, mode);
+  DPRINTF(E_DBG, L_DB, "Running query '%s'\n", query);
+
+  ret = db_blocking_prepare_v2(query, -1, &stmt, NULL);
+  if (ret != SQLITE_OK)
+    {
+      DPRINTF(E_LOG, L_DB, "Could not prepare statement: %s\n", sqlite3_errmsg(hdl));
+
+      sqlite3_free(query);
+      return NULL;
+    }
+
+  ret = db_blocking_step(stmt);
+  if (ret == SQLITE_DONE)
+    {
+      DPRINTF(E_DBG, L_DB, "End of query results\n");
+      sqlite3_free(query);
+      return NULL;
+    }
+  else if (ret != SQLITE_ROW)
+    {
+      DPRINTF(E_LOG, L_DB, "Could not step: %s\n", sqlite3_errmsg(hdl));
+      sqlite3_free(query);
+      return NULL;
+    }
+
+  new_mode = (char *) sqlite3_column_text(stmt, 0);
+  sqlite3_finalize(stmt);
+  sqlite3_free(query);
+  return new_mode;
+#undef Q_TMPL
+}
+
+static int
+db_pragma_get_synchronous()
+{
+  sqlite3_stmt *stmt;
+  char *query = "PRAGMA synchronous;";
+  int ret;
+
+  DPRINTF(E_DBG, L_DB, "Running query '%s'\n", query);
+
+  ret = db_blocking_prepare_v2(query, -1, &stmt, NULL);
+  if (ret != SQLITE_OK)
+    {
+      DPRINTF(E_LOG, L_DB, "Could not prepare statement: %s\n", sqlite3_errmsg(hdl));
+
+      sqlite3_free(query);
+      return 0;
+    }
+
+  ret = db_blocking_step(stmt);
+  if (ret == SQLITE_DONE)
+    {
+      DPRINTF(E_DBG, L_DB, "End of query results\n");
+      sqlite3_free(query);
+      return 0;
+    }
+  else if (ret != SQLITE_ROW)
+    {
+      DPRINTF(E_LOG, L_DB, "Could not step: %s\n", sqlite3_errmsg(hdl));
+      sqlite3_free(query);
+      return -1;
+    }
+
+  ret = sqlite3_column_int(stmt, 0);
+
+  sqlite3_finalize(stmt);
+  return ret;
+}
+
+static int
+db_pragma_set_synchronous(int synchronous)
+{
+#define Q_TMPL "PRAGMA synchronous=%d;"
+  sqlite3_stmt *stmt;
+  char *query;
+  int ret;
+
+  query = sqlite3_mprintf(Q_TMPL, synchronous);
+  DPRINTF(E_DBG, L_DB, "Running query '%s'\n", query);
+
+  ret = db_blocking_prepare_v2(query, -1, &stmt, NULL);
+  if (ret != SQLITE_OK)
+    {
+      DPRINTF(E_LOG, L_DB, "Could not prepare statement: %s\n", sqlite3_errmsg(hdl));
+
+      sqlite3_free(query);
+      return 0;
+    }
+
+  sqlite3_finalize(stmt);
+  sqlite3_free(query);
+  return 0;
+}
 
 int
 db_perthread_init(void)
 {
   char *errmsg;
   int ret;
+  int cache_size;
+  char *journal_mode;
+  int synchronous;
 
   ret = sqlite3_open(db_path, &hdl);
   if (ret != SQLITE_OK)
@@ -4391,6 +4561,29 @@ db_perthread_init(void)
 #ifdef DB_PROFILE
   sqlite3_profile(hdl, db_xprofile, NULL);
 #endif
+
+  cache_size = cfg_getint(cfg_getsec(cfg, "general"), "db_pragma_cache_size");
+  if (cache_size > -1)
+    {
+      db_pragma_set_cache_size(cache_size);
+      cache_size = db_pragma_get_cache_size();
+      DPRINTF(E_DBG, L_DB, "Database cache size in pages: %d\n", cache_size);
+    }
+
+  journal_mode = cfg_getstr(cfg_getsec(cfg, "general"), "db_pragma_journal_mode");
+  if (journal_mode)
+    {
+      journal_mode = db_pragma_set_journal_mode(journal_mode);
+      DPRINTF(E_DBG, L_DB, "Database journal mode: %s\n", journal_mode);
+    }
+
+  synchronous = cfg_getint(cfg_getsec(cfg, "general"), "db_pragma_synchronous");
+  if (synchronous > -1)
+    {
+      db_pragma_set_synchronous(synchronous);
+      synchronous = db_pragma_get_synchronous();
+      DPRINTF(E_DBG, L_DB, "Database synchronous: %d\n", synchronous);
+    }
 
   return 0;
 }


### PR DESCRIPTION
This adds the possibility to change the defaults from SQLite through the config file for:
- the size of the page cache (http://www.sqlite.org/pragma.html#pragma_cache_size)
- the synchronous flag (http://www.sqlite.org/pragma.html#pragma_synchronous)
- the used journal mode (http://www.sqlite.org/pragma.html#pragma_journal_mode)

Increasing the page cache size should increase the performance for select queries by reducing the number of necessary reads from the disk.
Setting the synchronous flag to false increases the performance for update and inserts, but could lead to a corrupted database file if the system crashes (see the docs).
Setting the journal mode to MEMORY or OFF should also increase the update and insert performance, but could also lead to a corrupted database file.

I have seen noticeable performance improvements on the bulk scan (especially the synchronous flag increases performance), but found it hard to measure the effect on select queries. @ejurgensen what do you  think about this?
