### PR TITLE
Fix skip to next song while the last song in Up Next is playing

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -1085,6 +1085,7 @@ source_reshuffle(void)
 
   source_shuffle(head, tail);
 
+  // Setting shuffle_head to the current song (head) will show all reshuffled songs in the playlist
   if (repeat == REPEAT_ALL)
     shuffle_head = head;
 }
@@ -1230,7 +1231,12 @@ source_next(int force)
 	if (cur_streaming && (ps == shuffle_head))
 	  {
 	    source_reshuffle();
-	    ps = shuffle_head;
+
+	    /* After source_reshuffle with "repeat all", shuffle_head is (re-)set to cur_streaming,
+	     * therefor get the next song in queue and set the start of the playlist to this song.
+	     */
+	    ps = cur_streaming->shuffle_next;
+	    shuffle_head = ps;
 	  }
 
 	limit = shuffle_head;


### PR DESCRIPTION
The problem with skip to next song and the combination of shuffle and repeat all was introduced with my commit a6c2a25. After a6c2a25 source_reshuffle() sets shuffle_head to the current playing song, therefor in source_next() the next song to be played needs to be the next after the current one instead of shuffle_head. 
