### PR TITLE
Don't segfault on invalid utf8 while sorting

### DIFF
--- a/src/filescanner.c
+++ b/src/filescanner.c
@@ -184,6 +184,7 @@ sort_tag_create(char **sort_tag, char *src_tag)
   ucs4_t puc;
   int numlen;
   size_t len;
+  int charlen;
 
   /* Note: include terminating NUL in string length for u8_normalize */
 
@@ -236,7 +237,11 @@ sort_tag_create(char **sort_tag, char *src_tag)
 	  if (number)
 	    append_number = 1; // A number has ended so time to append it
 	  else
-	    o_ptr = u8_stpncpy(o_ptr, i_ptr, u8_strmblen(i_ptr)); // No numbers in sight, just append char
+	    {
+              charlen = u8_strmblen(i_ptr);
+              if (charlen >= 0)
+	    	o_ptr = u8_stpncpy(o_ptr, i_ptr, charlen); // No numbers in sight, just append char
+	    }
 	}
 
       // Break if less than 100 bytes remain (prevent buffer overflow)


### PR DESCRIPTION
`strmblen` returns -1 on invalid sequences, which often-but-not-always causes a segfault when passed as length to `stpncpy`.

Stacktrace:

```
(gdb) backtrace
#0  0xb6cf544c in ?? () from /lib/i386-linux-gnu/libc.so.6
#1  0xb6e4fe0b in u8_stpncpy () from /usr/lib/i386-linux-gnu/libunistring.so.0
#2  0x0805829c in sort_tag_create (sort_tag=0xb5c13f24, src_tag=<optimized out>) at filescanner.c:239
#3  0x00000000 in ?? ()
```

This fixes #48 for as far as I can tell.
