### PR TITLE
only use queryfilter for playlists

### DIFF
--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1452,6 +1452,12 @@ dacp_reply_playqueueedit_add(struct evhttp_request *req, struct evbuffer *evbuf,
       // only use queryfilter if mode is not equal 0 (add to up next), 3 (play next) or 5 (add to up next)
       queuefilter = (mode == 0 || mode == 3 || mode == 5) ? NULL : evhttp_find_header(query, "queuefilter");
 
+      // only use queryfilter for playlists
+      if (queuefilter && !(strstr(queuefilter, "playlist:")))
+	{
+	  queuefilter = NULL;
+	}
+
       querymodifier = evhttp_find_header(query, "query-modifier");
       if (!querymodifier || (strcmp(querymodifier, "containers") != 0))
 	{


### PR DESCRIPTION
This adresses the issue reported by Tom_A in the forum (http://www.raspberrypi.org/forums/viewtopic.php?p=646835#p646835). I noticed it a while ago as it happens also by selecting a song from the artists view. This will add all songs from the artist to the playqueue. The cause of this is the queryfilter parameter in the add request from Apple Remote. 

Example request:
/ctrl-int/1/playqueue-edit?command=add&query='dmap.itemid:284'&queuefilter=artist:7031022036875718667&[...]

Ignoring the queuefilter solves this.

I have not checked how the latest iTunes version handles such requests, but back then iTunes did the same as forked-daapd does now (without this pr). 
