### PR TITLE
Fix for bug introduced by commit 67c092828d520e95d620f4c5a5a5cc90fdbd046...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -251,7 +251,7 @@ case "$host" in
     fi
 
     AC_CHECK_HEADERS([sys/eventfd.h])
-    AC_CHECK_FUNCS(eventfd_write)
+    AC_CHECK_FUNC(eventfd_write, AC_DEFINE(HAVE_EVENTFD, 1, [Define to 1 if you have eventfd]))
 
     AC_CHECK_HEADER(sys/signalfd.h, , AC_MSG_ERROR([signalfd required; glibc 2.9+ recommended]))
 


### PR DESCRIPTION
Commit [67c092828d520e95d620f4c5a5a5cc90fdbd0466](https://github.com/ejurgensen/forked-daapd/commit/67c092828d520e95d620f4c5a5a5cc90fdbd0466) changed configure.ac to look for eventfd_write instead of eventfd (using AC_CHECK_FUNCS).  This had the effect of making it so EVENTFD will never be used.  

AC_CHECK_FUNCS creates a conditional define for HAVE_ + the name of the function checked for, so changing AC_CHECK_FUNCS to look for eventfd_write also changed the conditional define to HAVE_EVENTFD_WRITE from HAVE_EVENTFD.  All of the conditionals that determine whether to use eventfd still look for a definition of HAVE_EVENTFD.  Since that is no longer defined, eventfd is never used, even if it is present. 

This commit corrects that issue by using AC_CHECK_FUNC instead of AC_CHECK_FUNCS, and expressly defining HAVE_EVENTFD if eventfd_write is present.
