### PR TITLE
fix delete query for removing files if a spotify playlist is deleted

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3340,7 +3340,7 @@ db_spotify_pl_delete(int id)
     {
       "DELETE FROM playlists WHERE id = %d;",
       "DELETE FROM playlistitems WHERE playlistid = %d;",
-      "DELETE FROM files WHERE path LIKE 'spotify:%%' AND NOT path IN (SELECT filepath FROM playlistitems WHERE id <> %d);",
+      "DELETE FROM files WHERE path LIKE 'spotify:%%' AND NOT path IN (SELECT filepath FROM playlistitems);",
     };
   char *query;
   int i;


### PR DESCRIPTION
The delete query for removing the entries in the files table in db_spotify_pl_delete looks wrong.

```
DELETE FROM files 
WHERE path LIKE 'spotify:%%' AND NOT path IN (
  SELECT filepath FROM playlistitems WHERE id <> %d
);
```

The argument id should be the playlist-id instead of the playlistitem-id in the query. I took it a step further by moving the delete of the files table entries to the first position, so that the subselect does not need to scan the whole playlistitems table.

I am not really familiar with the spotify integration code, so i might be wrong about this.
