### PR TITLE
Identify "android" user-agent as a remote client in transcode_needed()

### DIFF
--- a/src/transcode.c
+++ b/src/transcode.c
@@ -779,6 +779,8 @@ transcode_needed(const char *user_agent, const char *client_codecs, char *file_c
   // If client is a Remote we will AirPlay, which means we will transcode to PCM
   if (user_agent && strcasestr(user_agent, "remote"))
     return 1;
+  else if (user_agent && strcasestr(user_agent, "android"))
+    return 1;
 
   if (!file_codectype)
     {


### PR DESCRIPTION
While doing the performance tests with Retune as remote client, i noticed a lot of log messages like (actually this gets logged for each song during the request for the songlist):

```
[2014-12-28 06:33:51]    xcode: Determining transcoding status for codectype mpeg
[2014-12-28 06:33:51]    xcode: User-Agent: RetuneAndroid
[2014-12-28 06:33:51]    xcode: Could not identify client, using default codectype set
[2014-12-28 06:33:51]    xcode: Codectype supported by client, no transcoding needed
```

In transcode.c the remote clients are only identified if they contain "remote" in the user-agent string. In http_daap.c there is an additional check for "android". I added this check to the transcode_needed() function.
