### PR TITLE
Pass the foreign option to automake thus omitting README is not an error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_INIT([forked-daapd], [22.1])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
-AM_INIT_AUTOMAKE([-Wno-portability subdir-objects])
+AM_INIT_AUTOMAKE([foreign -Wno-portability subdir-objects])
 
 AC_USE_SYSTEM_EXTENSIONS
 


### PR DESCRIPTION
Unfortunately renaming the README results in a make error `Makefile.am: error: required file './README' not found`. The solution from http://stackoverflow.com/questions/15013672/use-autotools-with-readme-md is to add "foreign" to AM_INIT_AUTOMAKE. 

Of course another solution would be to revert the renaming. 

Sorry for not checking this before making the pr for the renaming ...
