### PR TITLE
[player] CD-like player behavior for skip next/prev (v2)

### DIFF
--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1885,6 +1885,7 @@ static int
 jsonapi_reply_player_next(struct httpd_request *hreq)
 {
   int ret;
+  struct player_status status;
 
   ret = player_playback_next();
   if (ret < 0)
@@ -1892,6 +1893,11 @@ jsonapi_reply_player_next(struct httpd_request *hreq)
       DPRINTF(E_LOG, L_WEB, "Error switching to next item.\n");
       return HTTP_INTERNAL;
     }
+
+  player_get_status(&status);
+  if (status.status == PLAY_STOPPED)
+    // in the non-playing state, we just move the playhead
+    return HTTP_NOCONTENT;
 
   ret = player_playback_start();
   if (ret < 0)
@@ -1907,6 +1913,7 @@ static int
 jsonapi_reply_player_previous(struct httpd_request *hreq)
 {
   int ret;
+  struct player_status status;
 
   ret = player_playback_prev();
   if (ret < 0)
@@ -1914,6 +1921,11 @@ jsonapi_reply_player_previous(struct httpd_request *hreq)
       DPRINTF(E_LOG, L_WEB, "Error switching to previous item.\n");
       return HTTP_INTERNAL;
     }
+
+  player_get_status(&status);
+  if (status.status == PLAY_STOPPED)
+    // in the non-playing state, we just move the playhead
+    return HTTP_NOCONTENT;
 
   ret = player_playback_start();
   if (ret < 0)

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -2536,7 +2536,7 @@ jsonapi_reply_queue_tracks_delete(struct httpd_request *hreq)
 static int
 jsonapi_reply_queue_clear(struct httpd_request *hreq)
 {
-  player_playback_stop();
+  player_playback_stop_clear();
   db_queue_clear(0);
 
   return HTTP_NOCONTENT;

--- a/src/player.c
+++ b/src/player.c
@@ -1937,7 +1937,11 @@ playing_now(void *arg, int *retval)
 static enum command_state
 playback_stop(void *arg, int *retval)
 {
-  if (player_state == PLAY_STOPPED)
+  bool check_state = arg ? *((bool*)arg) : false;
+
+  // check_state == false means we force the teardown of Q; we may be stopped 
+  // and have items in the Q as we position the playhead
+  if (check_state && player_state == PLAY_STOPPED)
     {
       *retval = 0;
       return COMMAND_END;
@@ -3217,8 +3221,19 @@ int
 player_playback_stop(void)
 {
   int ret;
+  bool check_state = true;
 
-  ret = commands_exec_sync(cmdbase, playback_stop, NULL, NULL);
+  ret = commands_exec_sync(cmdbase, playback_stop, NULL, &check_state);
+  return ret;
+}
+
+int
+player_playback_stop_clear(void)
+{
+  int ret;
+  bool check_state = false;
+
+  ret = commands_exec_sync(cmdbase, playback_stop, NULL, &check_state);
   return ret;
 }
 

--- a/src/player.h
+++ b/src/player.h
@@ -130,6 +130,9 @@ int
 player_playback_stop(void);
 
 int
+player_playback_stop_clear(void);
+
+int
 player_playback_pause(void);
 
 int


### PR DESCRIPTION
This is a rework of PR https://github.com/ejurgensen/forked-daapd/pull/610 to provide _CD-like_ functionality when skipping forwards/backward:

|player state|observation|
|-|-|
|`STOPPED`|`forward` or `backward` moves to next/previous track but does NOT start play.  If skipped to last track, another `forward` will move to first track; does NOT start play|
|`PLAYING` or `PAUSE` last track|`forward` moves to the start of play Q and continues play|
|`PLAYING` or `PAUSE` first track|`previous` moves to the end of play Q and continues play|

This reflects behaviour of many CD players.  Implementation (I think) addresses concerns from previous PR.