### PR TITLE
[web-src] allow user selectable 'rating' to 'now playing'

### DIFF
--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1576,7 +1576,8 @@ static int
 jsonapi_reply_player(struct httpd_request *hreq)
 {
   struct player_status status;
-  struct db_queue_item *queue_item;
+  struct db_queue_item *queue_item = NULL;
+  struct media_file_info *mfi = NULL;
   json_object *reply;
 
   player_get_status(&status);
@@ -1619,7 +1620,12 @@ jsonapi_reply_player(struct httpd_request *hreq)
 
   if (status.item_id)
     {
+      queue_item = db_queue_fetch_byitemid(status.item_id);
+      if (queue_item)
+	mfi = db_file_fetch_byid(queue_item->file_id);
+
       json_object_object_add(reply, "item_id", json_object_new_int(status.item_id));
+      json_object_object_add(reply, "item_rating", json_object_new_int(mfi ? mfi->rating : 0));
       json_object_object_add(reply, "item_length_ms", json_object_new_int(status.len_ms));
       json_object_object_add(reply, "item_progress_ms", json_object_new_int(status.pos_ms));
       json_object_object_add(reply, "artwork_url", json_object_new_string("/artwork/nowplaying"));
@@ -1630,14 +1636,17 @@ jsonapi_reply_player(struct httpd_request *hreq)
 
       if (queue_item)
 	{
+	  mfi = db_file_fetch_byid(queue_item->file_id);
+
 	  json_object_object_add(reply, "item_id", json_object_new_int(queue_item->id));
+	  json_object_object_add(reply, "item_rating", json_object_new_int(mfi ? mfi->rating : 0));
 	  json_object_object_add(reply, "item_length_ms", json_object_new_int(queue_item->song_length));
 	  json_object_object_add(reply, "item_progress_ms", json_object_new_int(0));
-	  free_queue_item(queue_item, 0);
 	}
       else
 	{
 	  json_object_object_add(reply, "item_id", json_object_new_int(0));
+	  json_object_object_add(reply, "item_rating", json_object_new_int(0));
 	  json_object_object_add(reply, "item_length_ms", json_object_new_int(0));
 	  json_object_object_add(reply, "item_progress_ms", json_object_new_int(0));
 	}
@@ -1645,6 +1654,8 @@ jsonapi_reply_player(struct httpd_request *hreq)
 
   CHECK_ERRNO(L_WEB, evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(reply)));
 
+  free_queue_item(queue_item, 0);
+  free_mfi(mfi, 0);
   jparse_free(reply);
 
   return HTTP_OK;

--- a/web-src/package.json
+++ b/web-src/package.json
@@ -25,6 +25,7 @@
     "vue-progressbar": "^0.7.4",
     "vue-range-slider": "^0.6.0",
     "vue-router": "^3.0.6",
+    "vue-star-rating": "^1.6.1",
     "vuedraggable": "^2.21.0",
     "vuex": "^3.1.1"
   },

--- a/web-src/src/components/ModalDialogGenre.vue
+++ b/web-src/src/components/ModalDialogGenre.vue
@@ -44,12 +44,20 @@ export default {
 
     queue_add: function () {
       this.$emit('close')
-      webapi.queue_expression_add('genre is "' + this.genre.name + '" and media_kind is music')
+      if (this.genre.uri) {
+        webapi.queue_add(this.genre.uri)
+      } else {
+        webapi.queue_expression_add('genre is "' + this.genre.name + '" and media_kind is music')
+      }
     },
 
     queue_add_next: function () {
       this.$emit('close')
-      webapi.queue_expression_add_next('genre is "' + this.genre.name + '" and media_kind is music')
+      if (this.genre.uri) {
+        webapi.queue_add_next(this.genre.uri)
+      } else {
+        webapi.queue_expression_add_next('genre is "' + this.genre.name + '" and media_kind is music')
+      }
     },
 
     open_genre: function () {

--- a/web-src/src/mystyles.css
+++ b/web-src/src/mystyles.css
@@ -182,3 +182,7 @@ section.fd-tabs-section + section.fd-content {
   margin-left: 16px;
   margin-right: 16px;
 }
+
+.vue-star-rating {
+  justify-content: center;
+}

--- a/web-src/src/mystyles.css
+++ b/web-src/src/mystyles.css
@@ -182,7 +182,3 @@ section.fd-tabs-section + section.fd-content {
   margin-left: 16px;
   margin-right: 16px;
 }
-
-.vue-star-rating {
-  justify-content: center;
-}

--- a/web-src/src/pages/PageArtistTracks.vue
+++ b/web-src/src/pages/PageArtistTracks.vue
@@ -33,7 +33,7 @@
           </template>
         </list-item-track>
         <modal-dialog-track :show="show_details_modal" :track="selected_track" @close="show_details_modal = false" />
-        <modal-dialog-artist :show="show_artist_details_modal" :artist="artist" @close="show_artist_details_modal = false" />
+        <modal-dialog-artist :show="show_artist_details_modal" :artist="modal_artist_obj" @close="show_artist_details_modal = false" />
       </template>
     </content-with-heading>
   </div>
@@ -83,6 +83,17 @@ export default {
   },
 
   computed: {
+    modal_artist_obj () {
+      var tracks = this.min_rating === 0 ? this.tracks.items : this.tracks.items.filter(a => a.rating >= this.min_rating)
+      return {
+        'id': this.id,
+        'name': this.artist.name,
+        'album_count': new Set(tracks.map(track => track.album_id)).size,
+        'track_count': tracks.length,
+        'uri': tracks.map(a => a.uri).join(',')
+      }
+    },
+
     index_list () {
       return [...new Set(this.tracks.items
         .map(track => track.title_sort.charAt(0).toUpperCase()))]

--- a/web-src/src/pages/PageArtistTracks.vue
+++ b/web-src/src/pages/PageArtistTracks.vue
@@ -9,6 +9,12 @@
       </template>
       <template slot="heading-right">
         <div class="buttons is-centered">
+          <star-rating v-model="min_rating"
+            :star-size="17"
+            :show-rating="false"
+            :max-rating="5"
+            :increment="0.5"
+            @rating-selected="show_rating"></star-rating>
           <a class="button is-small is-light is-rounded" @click="show_artist_details_modal = true">
             <span class="icon"><i class="mdi mdi-dots-horizontal mdi-18px"></i></span>
           </a>
@@ -19,7 +25,7 @@
       </template>
       <template slot="content">
         <p class="heading has-text-centered-mobile"><a class="has-text-link" @click="open_artist">{{ artist.album_count }} albums</a> | {{ artist.track_count }} tracks</p>
-        <list-item-track v-for="(track, index) in tracks.items" :key="track.id" :track="track" @click="play_track(index)">
+        <list-item-track v-for="(track, index) in tracks.items" :key="track.id" :track="track" v-if="track.rating >= min_rating" @click="play_track(index)">
           <template slot="actions">
             <a @click="open_dialog(track)">
               <span class="icon has-text-dark"><i class="mdi mdi-dots-vertical mdi-18px"></i></span>
@@ -40,6 +46,7 @@ import IndexButtonList from '@/components/IndexButtonList'
 import ListItemTrack from '@/components/ListItemTrack'
 import ModalDialogTrack from '@/components/ModalDialogTrack'
 import ModalDialogArtist from '@/components/ModalDialogArtist'
+import StarRating from 'vue-star-rating'
 import webapi from '@/webapi'
 
 const tracksData = {
@@ -59,12 +66,14 @@ const tracksData = {
 export default {
   name: 'PageArtistTracks',
   mixins: [ LoadDataBeforeEnterMixin(tracksData) ],
-  components: { ContentWithHeading, ListItemTrack, IndexButtonList, ModalDialogTrack, ModalDialogArtist },
+  components: { ContentWithHeading, ListItemTrack, IndexButtonList, ModalDialogTrack, ModalDialogArtist, StarRating },
 
   data () {
     return {
       artist: {},
       tracks: { items: [] },
+
+      min_rating: 0,
 
       show_details_modal: false,
       selected_track: {},
@@ -92,6 +101,13 @@ export default {
 
     play_track: function (position) {
       webapi.player_play_uri(this.tracks.items.map(a => a.uri).join(','), false, position)
+    },
+
+    show_rating: function (rating) {
+      if (rating === 0.5) {
+        rating = 0
+      }
+      this.min_rating = Math.ceil(rating) * 20
     },
 
     open_dialog: function (track) {

--- a/web-src/src/pages/PageGenreTracks.vue
+++ b/web-src/src/pages/PageGenreTracks.vue
@@ -33,7 +33,7 @@
           </template>
         </list-item-track>
         <modal-dialog-track :show="show_details_modal" :track="selected_track" @close="show_details_modal = false" />
-        <modal-dialog-genre :show="show_genre_details_modal" :genre="{ 'name': genre }" @close="show_genre_details_modal = false" />
+        <modal-dialog-genre :show="show_genre_details_modal" :genre="modal_obj" @close="show_genre_details_modal = false" />
       </template>
     </content-with-heading>
   </div>
@@ -80,6 +80,17 @@ export default {
   },
 
   computed: {
+    modal_obj () {
+      var tracks = this.min_rating === 0 ? this.tracks.items : this.tracks.items.filter(a => a.rating >= this.min_rating)
+      return {
+        'name': this.genre,
+        'album_count': new Set(tracks.map(track => track.album_id)).size,
+        'artist_count': new Set(tracks.map(track => track.artist_id)).size,
+        'track_count': tracks.length,
+        'uri': tracks.map(a => a.uri).join(',')
+      }
+    },
+
     index_list () {
       return [...new Set(this.tracks.items
         .map(track => track.title_sort.charAt(0).toUpperCase()))]

--- a/web-src/src/pages/PageGenreTracks.vue
+++ b/web-src/src/pages/PageGenreTracks.vue
@@ -9,6 +9,12 @@
       </template>
       <template slot="heading-right">
         <div class="buttons is-centered">
+          <star-rating v-model="min_rating"
+            :star-size="17"
+            :show-rating="false"
+            :max-rating="5"
+            :increment="0.5"
+            @rating-selected="show_rating"></star-rating>
           <a class="button is-small is-light is-rounded" @click="show_genre_details_modal = true">
             <span class="icon"><i class="mdi mdi-dots-horizontal mdi-18px"></i></span>
           </a>
@@ -19,7 +25,7 @@
       </template>
       <template slot="content">
         <p class="heading has-text-centered-mobile"><a class="has-text-link" @click="open_genre">albums</a> | {{ tracks.total }} tracks</p>
-        <list-item-track v-for="(track, index) in tracks.items" :key="track.id" :track="track" @click="play_track(index)">
+        <list-item-track v-for="(track, index) in tracks.items" :key="track.id" :track="track" v-if="track.rating >= min_rating" @click="play_track(index)">
           <template slot="actions">
             <a @click="open_dialog(track)">
               <span class="icon has-text-dark"><i class="mdi mdi-dots-vertical mdi-18px"></i></span>
@@ -40,6 +46,7 @@ import IndexButtonList from '@/components/IndexButtonList'
 import ListItemTrack from '@/components/ListItemTrack'
 import ModalDialogTrack from '@/components/ModalDialogTrack'
 import ModalDialogGenre from '@/components/ModalDialogGenre'
+import StarRating from 'vue-star-rating'
 import webapi from '@/webapi'
 
 const tracksData = {
@@ -56,12 +63,14 @@ const tracksData = {
 export default {
   name: 'PageGenreTracks',
   mixins: [ LoadDataBeforeEnterMixin(tracksData) ],
-  components: { ContentWithHeading, ListItemTrack, IndexButtonList, ModalDialogTrack, ModalDialogGenre },
+  components: { ContentWithHeading, ListItemTrack, IndexButtonList, ModalDialogTrack, ModalDialogGenre, StarRating },
 
   data () {
     return {
       tracks: { items: [] },
       genre: '',
+
+      min_rating: 0,
 
       show_details_modal: false,
       selected_track: {},
@@ -89,6 +98,13 @@ export default {
 
     play_track: function (position) {
       webapi.player_play_expression('genre is "' + this.genre + '" and media_kind is music', false, position)
+    },
+
+    show_rating: function (rating) {
+      if (rating === 0.5) {
+        rating = 0
+      }
+      this.min_rating = Math.ceil(rating) * 20
     },
 
     open_dialog: function (track) {

--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -40,7 +40,7 @@
             min="0"
             :max="state.item_length_ms"
             :value="item_progress_ms"
-            :disabled="state.state === 'stop'"
+            :disabled="state.state === 'stop' || seeking"
             step="1000"
             @change="seek" >
           </range-slider>
@@ -86,6 +86,7 @@ export default {
       artwork_visible: false,
 
       rating: 0,
+      is_seeking: false,
 
       show_details_modal: false,
       selected_item: {}
@@ -122,6 +123,10 @@ export default {
         return this.now_playing.artwork_url + '?maxwidth=600&maxheight=600'
       }
       return this.now_playing.artwork_url
+    },
+
+    seeking: function () {
+      return this.is_seeking
     }
   },
 
@@ -131,8 +136,13 @@ export default {
     },
 
     seek: function (newPosition) {
-      webapi.player_seek(newPosition).catch(() => {
+      this.is_seeking = true
+      this.item_progress_ms = newPosition
+      webapi.player_seek(newPosition).then(() => {
+        this.is_seeking = false
+      }).catch(() => {
         this.item_progress_ms = this.state.item_progress_ms
+        this.is_seeking = false
       })
     },
 

--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -5,10 +5,12 @@
         <h1 class="title is-4">
           {{ now_playing.title }}
           <div class="fd-has-padding-left-right"><star-rating v-model="rating"
-            :star-size="15"
+            :star-size="17"
+            :padding="3"
             :show-rating="false"
             :max-rating="5"
             :increment="0.5"
+            :inline="true"
             @rating-selected="rate_track"></star-rating></div>
         </h1>
         <h2 class="title is-6">

--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -150,7 +150,7 @@ export default {
       }
       this.rating = Math.ceil(rating)
       this.state.item_rating = this.rating * 20
-      webapi.library_track_update(this.now_playing.track_id, { 'rating': this.rating * 20 })
+      webapi.library_track_set_rating(this.now_playing.track_id, this.rating * 20)
     },
 
     open_dialog: function (item) {

--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -4,6 +4,12 @@
       <div class="container has-text-centered fd-has-margin-top">
         <h1 class="title is-4">
           {{ now_playing.title }}
+          <div class="fd-has-padding-left-right" v-show="load_rating()"><star-rating v-model="rating"
+            :star-size="15"
+            :show-rating="false"
+            :max-rating="5"
+            :increment="0.5"
+            @rating-selected="rate_track"></star-rating></div>
         </h1>
         <h2 class="title is-6">
           {{ now_playing.artist }}
@@ -63,18 +69,21 @@ import PlayerButtonShuffle from '@/components/PlayerButtonShuffle'
 import PlayerButtonConsume from '@/components/PlayerButtonConsume'
 import PlayerButtonRepeat from '@/components/PlayerButtonRepeat'
 import RangeSlider from 'vue-range-slider'
+import StarRating from 'vue-star-rating'
 import webapi from '@/webapi'
 import * as types from '@/store/mutation_types'
 
 export default {
   name: 'PageNowPlaying',
-  components: { ModalDialogQueueItem, PlayerButtonPlayPause, PlayerButtonNext, PlayerButtonPrevious, PlayerButtonShuffle, PlayerButtonConsume, PlayerButtonRepeat, RangeSlider },
+  components: { ModalDialogQueueItem, PlayerButtonPlayPause, PlayerButtonNext, PlayerButtonPrevious, PlayerButtonShuffle, PlayerButtonConsume, PlayerButtonRepeat, RangeSlider, StarRating },
 
   data () {
     return {
       item_progress_ms: 0,
       interval_id: 0,
       artwork_visible: false,
+
+      rating: -1,
 
       show_details_modal: false,
       selected_item: {}
@@ -131,6 +140,23 @@ export default {
 
     artwork_error: function () {
       this.artwork_visible = false
+    },
+
+    load_rating: function () {
+      if (this.rating < 0 && this.now_playing.track_id) {
+        webapi.library_track(this.now_playing.track_id).then(({ data }) => {
+          this.rating = Math.ceil(data.rating / 20)
+        })
+      }
+      return this.rating >= 0
+    },
+
+    rate_track: function (rating) {
+      if (rating === 0.5) {
+        rating = 0
+      }
+      this.rating = Math.ceil(rating)
+      webapi.library_track_update(this.now_playing.track_id, { 'rating': this.rating * 20 })
     },
 
     open_dialog: function (item) {

--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -4,7 +4,7 @@
       <div class="container has-text-centered fd-has-margin-top">
         <h1 class="title is-4">
           {{ now_playing.title }}
-          <div class="fd-has-padding-left-right" v-show="load_rating()"><star-rating v-model="rating"
+          <div class="fd-has-padding-left-right"><star-rating v-model="rating"
             :star-size="15"
             :show-rating="false"
             :max-rating="5"
@@ -83,7 +83,7 @@ export default {
       interval_id: 0,
       artwork_visible: false,
 
-      rating: -1,
+      rating: 0,
 
       show_details_modal: false,
       selected_item: {}
@@ -142,20 +142,12 @@ export default {
       this.artwork_visible = false
     },
 
-    load_rating: function () {
-      if (this.rating < 0 && this.now_playing.track_id) {
-        webapi.library_track(this.now_playing.track_id).then(({ data }) => {
-          this.rating = Math.ceil(data.rating / 20)
-        })
-      }
-      return this.rating >= 0
-    },
-
     rate_track: function (rating) {
       if (rating === 0.5) {
         rating = 0
       }
       this.rating = Math.ceil(rating)
+      this.state.item_rating = this.rating * 20
       webapi.library_track_update(this.now_playing.track_id, { 'rating': this.rating * 20 })
     },
 
@@ -175,6 +167,7 @@ export default {
       if (this.state.state === 'play') {
         this.interval_id = window.setInterval(this.tick, 1000)
       }
+      this.rating = this.state.item_rating / 20
     }
   }
 }

--- a/web-src/src/store/index.js
+++ b/web-src/src/store/index.js
@@ -28,6 +28,7 @@ export default new Vuex.Store({
       'shuffle': false,
       'volume': 0,
       'item_id': 0,
+      'item_rating': 0,
       'item_length_ms': 0,
       'item_progress_ms': 0
     },

--- a/web-src/src/webapi/index.js
+++ b/web-src/src/webapi/index.js
@@ -287,6 +287,13 @@ export default {
     return axios.put('/api/library/tracks/' + trackId, undefined, { params: attributes })
   },
 
+  library_track_set_rating (trackId, rating) {
+    return axios.put('/api/library/tracks/' + trackId, undefined, { params: { 'rating': rating } }).then((response) => {
+      store.dispatch('add_notification', { text: 'track rating updated', type: 'info', timeout: 1500 })
+      return Promise.resolve(response)
+    })
+  },
+
   library_files (directory = undefined) {
     var filesParams = { 'directory': directory }
     return axios.get('/api/library/files', {


### PR DESCRIPTION
PR to allow user to set track rating using exiting `api/library/tracks/`_track_id_`?rating=3`.  Users reset by select a rating of 0.5, other 1/2 ratings get rounded up.

![rating](https://user-images.githubusercontent.com/18466811/55674283-993b5d80-58aa-11e9-872c-08287956008b.png)

~~One area of conflict: if server is using `rating_updates=true` then the `rating` is 0..100 and the server will overwrite this rating at the `db_file_inc_playcount()`.~~ shouldn't be a problem - the db rating takes `rating` as it stands into consideration for its calc

`artist tracks` and `genre tracks` pages allows user to filter/display rated tracks
![rating](https://user-images.githubusercontent.com/18466811/55683171-b4eb4600-5934-11e9-913f-ab278ebcadd1.png)
