### PR TITLE
[httpd] dedicated streaming evbase/evhttp

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -33,6 +33,9 @@ general {
 
 	# Websocket port for the web interface.
 #	websocket_port = 3688
+#
+	# port for sttreaming mp3
+#	stream_port = 3680
 
 	# Sets who is allowed to connect without authorisation. This applies to
 	# client types like Remotes, DAAP clients (iTunes) and to the web

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -51,6 +51,7 @@ static cfg_opt_t sec_general[] =
     CFG_INT_CB("loglevel", E_LOG, CFGF_NONE, &cb_loglevel),
     CFG_STR("admin_password", NULL, CFGF_NONE),
     CFG_INT("websocket_port", 3688, CFGF_NONE),
+    CFG_INT("stream_port", 3680, CFGF_NONE),
     CFG_STR_LIST("trusted_networks", "{localhost,192.168,fd}", CFGF_NONE),
     CFG_BOOL("ipv6", cfg_true, CFGF_NONE),
     CFG_STR("cache_path", STATEDIR "/cache/" PACKAGE "/cache.db", CFGF_NONE),

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -1675,7 +1675,7 @@ httpd_init(const char *webroot)
       goto rsp_fail;
     }
 
-  ret = daap_init();
+  ret = daap_init(evbase_httpd);
   if (ret < 0)
     {
       DPRINTF(E_FATAL, L_HTTPD, "DAAP protocol init failed\n");
@@ -1683,7 +1683,7 @@ httpd_init(const char *webroot)
       goto daap_fail;
     }
 
-  ret = dacp_init();
+  ret = dacp_init(evbase_httpd);
   if (ret < 0)
     {
       DPRINTF(E_FATAL, L_HTTPD, "DACP protocol init failed\n");
@@ -1725,7 +1725,7 @@ httpd_init(const char *webroot)
     }
 #endif
 
-  streaming_init();
+  streaming_init(evbase_httpd);
 
 #ifdef HAVE_EVENTFD
   exit_efd = eventfd(0, EFD_CLOEXEC);

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -122,7 +122,6 @@ static const struct content_type_map ext2ctype[] =
 static const char *http_reply_401 = "<html><head><title>401 Unauthorized</title></head><body>Authorization required</body></html>";
 
 static const char *webroot_directory;
-struct event_base *evbase_httpd;
 
 #ifdef HAVE_EVENTFD
 static int exit_efd;
@@ -131,11 +130,24 @@ static int exit_pipe[2];
 #endif
 static int httpd_exit;
 static struct event *exitev;
-static struct evhttp *evhttpd;
-static pthread_t tid_httpd;
+
+struct httpd_ctx
+{
+  pthread_t tid;
+  struct event_base *evb;
+  struct evhttp     *evh;
+  int port;
+
+  void (*handler)(struct evhttp_request *, struct httpd_uri_parsed *);
+};
+
+static void httpd_generic_hdl(struct evhttp_request *, struct httpd_uri_parsed *);
+static void httpd_stream_hdl(struct evhttp_request *, struct httpd_uri_parsed *);
+
+struct httpd_ctx  evhttpd        = { 0, NULL, NULL, -1, httpd_generic_hdl };
+struct httpd_ctx  evhttpd_stream = { 0, NULL, NULL, -1, httpd_stream_hdl  };
 
 static const char *allow_origin;
-static int httpd_port;
 
 #ifdef HAVE_LIBEVENT2_OLD
 struct stream_ctx *g_st;
@@ -762,6 +774,7 @@ stream_fail_cb(struct evhttp_connection *evcon, void *arg)
 static void *
 httpd(void *arg)
 {
+  struct httpd_ctx *ctx = (struct httpd_ctx*)arg;
   int ret;
 
   ret = db_perthread_init();
@@ -772,7 +785,7 @@ httpd(void *arg)
       pthread_exit(NULL);
     }
 
-  event_base_dispatch(evbase_httpd);
+  event_base_dispatch(ctx->evb);
 
   if (!httpd_exit)
     DPRINTF(E_FATAL, L_HTTPD, "HTTPd event loop terminated ahead of time!\n");
@@ -785,14 +798,74 @@ httpd(void *arg)
 static void
 exit_cb(int fd, short event, void *arg)
 {
-  event_base_loopbreak(evbase_httpd);
+  struct httpd_ctx* ctx = (struct httpd_ctx*)arg;
+  event_base_loopbreak(ctx->evb);
 
   httpd_exit = 1;
 }
 
 static void
+httpd_stream_hdl(struct evhttp_request *req, struct httpd_uri_parsed *parsed)
+{
+  if (streaming_is_request(parsed->path))
+    {
+      streaming_request(req, parsed);
+      return;
+    }
+  httpd_send_error(req, HTTP_BADREQUEST, "Bad Request");
+}
+
+static void
+httpd_generic_hdl(struct evhttp_request *req, struct httpd_uri_parsed *parsed)
+{
+  if (strcmp(parsed->path, "/") == 0)
+    goto serve_file;
+
+  /* Dispatch protocol-specific handlers */
+  if (dacp_is_request(parsed->path))
+    {
+      dacp_request(req, parsed);
+      goto out;
+    }
+  else if (daap_is_request(parsed->path))
+    {
+      daap_request(req, parsed);
+      goto out;
+    }
+  else if (jsonapi_is_request(parsed->path))
+    {
+      jsonapi_request(req, parsed);
+      goto out;
+    }
+  else if (artworkapi_is_request(parsed->path))
+    {
+      artworkapi_request(req, parsed);
+      goto out;
+    }
+  else if (oauth_is_request(parsed->path))
+    {
+      oauth_request(req, parsed);
+      goto out;
+    }
+  else if (rsp_is_request(parsed->path))
+    {
+      rsp_request(req, parsed);
+      goto out;
+    }
+
+  DPRINTF(E_DBG, L_HTTPD, "HTTP request: '%s'\n", parsed->uri);
+
+ serve_file:
+  serve_file(req, parsed->path);
+
+ out:
+  return;
+}
+
+static void
 httpd_gen_cb(struct evhttp_request *req, void *arg)
 {
+  struct httpd_ctx *ctx = (struct httpd_ctx*)arg;
   struct evkeyvalq *input_headers;
   struct evkeyvalq *output_headers;
   struct httpd_uri_parsed *parsed;
@@ -835,55 +908,10 @@ httpd_gen_cb(struct evhttp_request *req, void *arg)
       goto out;
     }
 
-  if (strcmp(parsed->path, "/") == 0)
-    {
-      goto serve_file;
-    }
+  // delegate to the httpd server specific handler (ie generic or streaming)
+  ctx->handler(req, parsed);
 
-  /* Dispatch protocol-specific handlers */
-  if (dacp_is_request(parsed->path))
-    {
-      dacp_request(req, parsed);
-      goto out;
-    }
-  else if (daap_is_request(parsed->path))
-    {
-      daap_request(req, parsed);
-      goto out;
-    }
-  else if (jsonapi_is_request(parsed->path))
-    {
-      jsonapi_request(req, parsed);
-      goto out;
-    }
-  else if (artworkapi_is_request(parsed->path))
-    {
-      artworkapi_request(req, parsed);
-      goto out;
-    }
-  else if (streaming_is_request(parsed->path))
-    {
-      streaming_request(req, parsed);
-      goto out;
-    }
-  else if (oauth_is_request(parsed->path))
-    {
-      oauth_request(req, parsed);
-      goto out;
-    }
-  else if (rsp_is_request(parsed->path))
-    {
-      rsp_request(req, parsed);
-      goto out;
-    }
-
-  DPRINTF(E_DBG, L_HTTPD, "HTTP request: '%s'\n", parsed->uri);
-
-  /* Serve web interface files */
- serve_file:
-  serve_file(req, parsed->path);
-
- out:
+out:
   httpd_uri_free(parsed);
 }
 
@@ -1257,7 +1285,7 @@ httpd_stream_file(struct evhttp_request *req, int id)
       goto out_cleanup;
     }
 
-  st->ev = event_new(evbase_httpd, -1, EV_TIMEOUT, stream_cb, st);
+  st->ev = event_new(evhttpd.evb, -1, EV_TIMEOUT, stream_cb, st);
   evutil_timerclear(&tv);
   if (!st->ev || (event_add(st->ev, &tv) < 0))
     {
@@ -1659,8 +1687,9 @@ httpd_init(const char *webroot)
     }
   webroot_directory = webroot;
 
-  evbase_httpd = event_base_new();
-  if (!evbase_httpd)
+  evhttpd.evb = event_base_new();
+  evhttpd_stream.evb = event_base_new();
+  if (!evhttpd.evb || !evhttpd_stream.evb)
     {
       DPRINTF(E_FATAL, L_HTTPD, "Could not create an event base\n");
 
@@ -1675,7 +1704,7 @@ httpd_init(const char *webroot)
       goto rsp_fail;
     }
 
-  ret = daap_init(evbase_httpd);
+  ret = daap_init(evhttpd.evb);
   if (ret < 0)
     {
       DPRINTF(E_FATAL, L_HTTPD, "DAAP protocol init failed\n");
@@ -1683,7 +1712,7 @@ httpd_init(const char *webroot)
       goto daap_fail;
     }
 
-  ret = dacp_init(evbase_httpd);
+  ret = dacp_init(evhttpd.evb);
   if (ret < 0)
     {
       DPRINTF(E_FATAL, L_HTTPD, "DACP protocol init failed\n");
@@ -1725,7 +1754,7 @@ httpd_init(const char *webroot)
     }
 #endif
 
-  streaming_init(evbase_httpd);
+  streaming_init(evhttpd_stream.evb);
 
 #ifdef HAVE_EVENTFD
   exit_efd = eventfd(0, EFD_CLOEXEC);
@@ -1736,7 +1765,7 @@ httpd_init(const char *webroot)
       goto pipe_fail;
     }
 
-  exitev = event_new(evbase_httpd, exit_efd, EV_READ, exit_cb, NULL);
+  exitev = event_new(evhttpd.evb, exit_efd, EV_READ, exit_cb, &evhttpd);
 #else
 # ifdef HAVE_PIPE2
   ret = pipe2(exit_pipe, O_CLOEXEC);
@@ -1750,7 +1779,7 @@ httpd_init(const char *webroot)
       goto pipe_fail;
     }
 
-  exitev = event_new(evbase_httpd, exit_pipe[0], EV_READ, exit_cb, NULL);
+  exitev = event_new(evhttpd.evb, exit_pipe[0], EV_READ, exit_cb, &evhttpd);
 #endif /* HAVE_EVENTFD */
   if (!exitev)
     {
@@ -1760,8 +1789,9 @@ httpd_init(const char *webroot)
     }
   event_add(exitev, NULL);
 
-  evhttpd = evhttp_new(evbase_httpd);
-  if (!evhttpd)
+  evhttpd.evh = evhttp_new(evhttpd.evb);
+  evhttpd_stream.evh = evhttp_new(evhttpd_stream.evb);
+  if (!evhttpd.evh || !evhttpd_stream.evh)
     {
       DPRINTF(E_FATAL, L_HTTPD, "Could not create HTTP server\n");
 
@@ -1769,65 +1799,93 @@ httpd_init(const char *webroot)
     }
 
   v6enabled = cfg_getbool(cfg_getsec(cfg, "general"), "ipv6");
-  httpd_port = cfg_getint(cfg_getsec(cfg, "library"), "port");
+  evhttpd.port = cfg_getint(cfg_getsec(cfg, "library"), "port");
+  evhttpd_stream.port = cfg_getint(cfg_getsec(cfg, "general"), "stream_port");
 
   // For CORS headers
   allow_origin = cfg_getstr(cfg_getsec(cfg, "general"), "allow_origin");
   if (allow_origin)
     {
       if (strlen(allow_origin) != 0)
-	evhttp_set_allowed_methods(evhttpd, EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_PUT | EVHTTP_REQ_DELETE | EVHTTP_REQ_HEAD | EVHTTP_REQ_OPTIONS);
+        evhttp_set_allowed_methods(evhttpd.evh, EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_PUT | EVHTTP_REQ_DELETE | EVHTTP_REQ_HEAD | EVHTTP_REQ_OPTIONS);
       else
 	allow_origin = NULL;
     }
+  evhttp_set_allowed_methods(evhttpd_stream.evh, EVHTTP_REQ_GET | EVHTTP_REQ_HEAD | EVHTTP_REQ_OPTIONS);
 
   if (v6enabled)
     {
-      ret = evhttp_bind_socket(evhttpd, "::", httpd_port);
+      ret = evhttp_bind_socket(evhttpd.evh, "::", evhttpd.port);
       if (ret < 0)
 	{
-	  DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv6, falling back to IPv4\n", httpd_port);
+	  DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv6, falling back to IPv4\n", evhttpd.port);
 	  v6enabled = 0;
 	}
+      else
+        evhttp_bind_socket(evhttpd_stream.evh, "::", evhttpd_stream.port);
     }
 
-  ret = evhttp_bind_socket(evhttpd, "0.0.0.0", httpd_port);
+  ret = evhttp_bind_socket(evhttpd.evh, "0.0.0.0", evhttpd.port);
   if (ret < 0)
     {
       if (!v6enabled)
 	{
-	  DPRINTF(E_FATAL, L_HTTPD, "Could not bind to port %d (forked-daapd already running?)\n", httpd_port);
+	  DPRINTF(E_FATAL, L_HTTPD, "Could not bind to port %d (forked-daapd already running?)\n", evhttpd.port);
 	  goto bind_fail;
 	}
 
 #ifndef __linux__
       // Linux will listen on both ipv6 and ipv4, but FreeBSD won't
-      DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv4, listening on IPv6 only\n", httpd_port);
+      DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv4, listening on IPv6 only\n", evhttpd.port);
 #endif
     }
+  ret = evhttp_bind_socket(evhttpd_stream.evh, "0.0.0.0", evhttpd_stream.port);
+  if (ret < 0)
+    {
+      if (!v6enabled)
+	{
+	  DPRINTF(E_FATAL, L_HTTPD, "Could not bind to httpd stream port %d\n", evhttpd_stream.port);
+	  goto bind_fail;
+	}
 
-  evhttp_set_gencb(evhttpd, httpd_gen_cb, NULL);
+#ifndef __linux__
+      // Linux will listen on both ipv6 and ipv4, but FreeBSD won't
+      DPRINTF(E_LOG, L_HTTPD, "Could not bind to httpd stream port %d with IPv4, listening on IPv6 only\n", evhttpd_stream.port);
+#endif
+    }
+  evhttp_set_gencb(evhttpd.evh,        httpd_gen_cb, &evhttpd);
+  evhttp_set_gencb(evhttpd_stream.evh, httpd_gen_cb, &evhttpd_stream);
 
-  ret = pthread_create(&tid_httpd, NULL, httpd, NULL);
+  ret = pthread_create(&evhttpd.tid, NULL, httpd, &evhttpd);
   if (ret != 0)
     {
       DPRINTF(E_FATAL, L_HTTPD, "Could not spawn HTTPd thread: %s\n", strerror(errno));
 
       goto thread_fail;
     }
+  ret = pthread_create(&evhttpd_stream.tid, NULL, httpd, &evhttpd_stream);
+  if (ret != 0)
+    {
+      DPRINTF(E_FATAL, L_HTTPD, "Could not spawn HTTPd streaming thread: %s\n", strerror(errno));
+
+      goto thread_fail;
+    }
 
 #if defined(HAVE_PTHREAD_SETNAME_NP)
-  pthread_setname_np(tid_httpd, "httpd");
+  pthread_setname_np(evhttpd.tid, "httpd");
+  pthread_setname_np(evhttpd_stream.tid, "httpd-stream");
 #elif defined(HAVE_PTHREAD_SET_NAME_NP)
-  pthread_set_name_np(tid_httpd, "httpd");
+  pthread_set_name_np(evhttpd.tid, "httpd");
+  pthread_set_name_np(evhttpd_stream.tid, "httpd-stream");
 #endif
 
   return 0;
 
  thread_fail:
  bind_fail:
-  evhttp_free(evhttpd);
+  evhttp_free(evhttpd.evh);
  evhttpd_fail:
+  evhttp_free(evhttpd_stream.evh);
   event_free(exitev);
  exitev_fail:
 #ifdef HAVE_EVENTFD
@@ -1854,7 +1912,8 @@ httpd_init(const char *webroot)
  daap_fail:
   rsp_deinit();
  rsp_fail:
-  event_base_free(evbase_httpd);
+  event_base_free(evhttpd_stream.evb);
+  event_base_free(evhttpd.evb);
 
   return -1;
 }
@@ -1885,7 +1944,16 @@ httpd_deinit(void)
     }
 #endif
 
-  ret = pthread_join(tid_httpd, NULL);
+  ret = pthread_join(evhttpd.tid, NULL);
+  if (ret != 0)
+    {
+      DPRINTF(E_FATAL, L_HTTPD, "Could not join HTTPd thread: %s\n", strerror(errno));
+
+      return;
+    }
+  event_base_loopbreak(evhttpd_stream.evb);
+
+  ret = pthread_join(evhttpd_stream.tid, NULL);
   if (ret != 0)
     {
       DPRINTF(E_FATAL, L_HTTPD, "Could not join HTTPd thread: %s\n", strerror(errno));
@@ -1910,6 +1978,8 @@ httpd_deinit(void)
   close(exit_pipe[1]);
 #endif
   event_free(exitev);
-  evhttp_free(evhttpd);
-  event_base_free(evbase_httpd);
+  evhttp_free(evhttpd.evh);
+  evhttp_free(evhttpd_stream.evh);
+  event_base_free(evhttpd_stream.evb);
+  event_base_free(evhttpd.evb);
 }

--- a/src/httpd_daap.c
+++ b/src/httpd_daap.c
@@ -57,7 +57,7 @@
 
 
 /* httpd event base, from httpd.c */
-extern struct event_base *evbase_httpd;
+static struct event_base *evbase_httpd;
 
 /* Max number of sessions and session timeout
  * Many clients (including iTunes) don't seem to respect the timeout capability
@@ -2433,11 +2433,13 @@ daap_reply_build(const char *uri, const char *user_agent, int is_remote)
 }
 
 int
-daap_init(void)
+daap_init(struct event_base* evbase)
 {
   char buf[64];
   int i;
   int ret;
+
+  evbase_httpd = evbase;
 
   srand((unsigned)time(NULL));
   current_rev = 2;

--- a/src/httpd_daap.h
+++ b/src/httpd_daap.h
@@ -5,7 +5,7 @@
 #include "httpd.h"
 
 int
-daap_init(void);
+daap_init(struct event_base*);
 
 void
 daap_deinit(void);

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -53,7 +53,7 @@
 #define DACP_VOLUME_STEP 5
 
 /* httpd event base, from httpd.c */
-extern struct event_base *evbase_httpd;
+static struct event_base *evbase_httpd;
 
 struct dacp_update_request {
   struct evhttp_request *req;
@@ -2892,7 +2892,7 @@ dacp_is_request(const char *path)
 }
 
 int
-dacp_init(void)
+dacp_init(struct event_base* evbase)
 {
   char buf[64];
   int i;
@@ -2912,6 +2912,8 @@ dacp_init(void)
   dummy_queue_item.artist = CFG_NAME_UNKNOWN_ARTIST;
   dummy_queue_item.album = CFG_NAME_UNKNOWN_ALBUM;
   dummy_queue_item.genre = CFG_NAME_UNKNOWN_GENRE;
+
+  evbase_httpd = evbase;
 
 #ifdef HAVE_EVENTFD
   update_efd = eventfd(0, EFD_CLOEXEC);

--- a/src/httpd_dacp.h
+++ b/src/httpd_dacp.h
@@ -5,7 +5,7 @@
 #include "httpd.h"
 
 int
-dacp_init(void);
+dacp_init(struct event_base*);
 
 void
 dacp_deinit(void);

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -768,6 +768,7 @@ jsonapi_reply_config(struct httpd_request *hreq)
   websocket_port = 0;
 #endif
   json_object_object_add(jreply, "websocket_port", json_object_new_int(websocket_port));
+  json_object_object_add(jreply, "stream_port", json_object_new_int(cfg_getint(cfg_getsec(cfg, "general"), "stream_port")));
 
   // forked-daapd version
   json_object_object_add(jreply, "version", json_object_new_string(VERSION));

--- a/src/httpd_streaming.c
+++ b/src/httpd_streaming.c
@@ -41,7 +41,7 @@
 #include "db.h"
 
 /* httpd event base, from httpd.c */
-extern struct event_base *evbase_httpd;
+static struct event_base *evbase_httpd;
 
 // Seconds between sending silence when player is idle
 // (to prevent client from hanging up)
@@ -627,7 +627,7 @@ streaming_is_request(const char *path)
 }
 
 int
-streaming_init(void)
+streaming_init(struct event_base* evbase)
 {
   int ret;
   cfg_t *cfgsec;
@@ -664,6 +664,8 @@ streaming_init(void)
     streaming_icy_metaint = val;
   else
     DPRINTF(E_INFO, L_STREAMING, "Unsupported icy_metaint=%d, supported range: 4096..131072, defaulting to %d\n", val, streaming_icy_metaint);
+
+  evbase_httpd = evbase;
 
   pthread_mutex_init(&streaming_sessions_lck, NULL);
 

--- a/src/httpd_streaming.h
+++ b/src/httpd_streaming.h
@@ -21,7 +21,7 @@ int
 streaming_is_request(const char *path);
 
 int
-streaming_init(void);
+streaming_init(struct event_base*);
 
 void
 streaming_deinit(void);


### PR DESCRIPTION
Minor refactor `httpd` to allow introducing other `evhttp` servers and their own `event_base` for dedicated event loops.

Splits off mp3 streaming to its own http server and event loop.

Closes https://github.com/ejurgensen/forked-daapd/issues/793