### PR TITLE
[dacp] play item from 'up next' when stopped

### DIFF
--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1235,10 +1235,10 @@ dacp_reply_cue_play(struct httpd_request *hreq)
       else
 	{
 	  /* Play from Up Next queue */
-	  if (status.status == PLAY_STOPPED && pos > 0)
-	    pos--;
-
-	  queue_item = db_queue_fetch_byposrelativetoitem(pos, status.item_id, status.shuffle);
+	  if (status.status == PLAY_STOPPED)
+            queue_item = db_queue_fetch_bypos(pos, status.shuffle);
+          else
+            queue_item = db_queue_fetch_byposrelativetoitem(pos, status.item_id, status.shuffle);
 	  if (!queue_item)
 	    {
 	      DPRINTF(E_LOG, L_DACP, "Could not fetch item from queue: pos=%d, now playing=%d\n", pos, status.item_id);


### PR DESCRIPTION
IOS remote - Playback does not start when user selects a track on the "up next" screen when server is stopped/restarted.

To reproduce:
* stop player or restart server 
* clear Q
* adds items to Q using 'add next'
* select item on 'up next'

Error reported:
```
[DEBUG]     dacp: DACP request: '/ctrl-int/1/playqueue-edit?command=playnow&index=1&session-id=886488353'
[DEBUG]       db: Fetch by pos: pos (0) relative to item with id (0)
[DEBUG]       db: Running query 'BEGIN TRANSACTION;'
[DEBUG]       db: Fetch by pos: pos (0) relative to item with id (0)
[DEBUG]       db: Running query 'SELECT pos FROM queue WHERE id = 0;'
[ INFO]       db: No matching row found for query: SELECT pos FROM queue WHERE id = 0;
[DEBUG]       db: Running query 'END TRANSACTION;'
[  LOG]       db: Error fetching queue item by pos relative to item id
[  LOG]     dacp: Could not fetch item from queue: pos=0, now playing=0
```
