### PR TITLE
[dacp] play-next when server is stopped and empty

### DIFF
--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -300,6 +300,7 @@ dacp_queueitem_add(const char *query, const char *queuefilter, const char *sort,
   int len;
   char buf[1024];
   struct player_status status;
+  uint32_t count;
 
   if (query)
     {
@@ -410,8 +411,9 @@ dacp_queueitem_add(const char *query, const char *queuefilter, const char *sort,
     }
 
   player_get_status(&status);
-
-  if (mode == 3)
+  count = 0;
+  db_queue_get_count(&count);
+  if (mode == 3 && count > 0)
     ret = db_queue_add_by_queryafteritemid(&qp, status.item_id);
   else
     ret = db_queue_add_by_query(&qp, status.shuffle, status.item_id, -1, NULL, NULL);


### PR DESCRIPTION
IOS remote - Playback does not start when user selects "play next" screen when server is stopped/restarted.

To reproduce:
* stop player or restart server 
* clear Q
* find album or playlist 
* select 'play next'

Error in log
```
[DEBUG]     dacp: DACP request: '/ctrl-int/1/playqueue-edit?command=add&query='daap.songalbumid:1722214560191693504'&mode=3&session-id=1488755350'
[DEBUG]     daap: Trying DAAP query -'daap.songalbumid:1722214560191693504'-
[DEBUG]     daap: DAAP SQL query: -(f.songalbumid = 1722214560191693504)-
[DEBUG]     dacp: Found index song (id 36)
[DEBUG]     daap: Trying DAAP query -'daap.songalbumid:1722214560191693504'-
[DEBUG]     daap: DAAP SQL query: -(f.songalbumid = 1722214560191693504)-
[  LOG]     dacp: Could not build song queue
```
