### PR TITLE
Replace artwork fix

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -403,6 +403,7 @@ static const ssize_t dbgri_cols_map[] =
     dbgri_offsetof(time_added),
     dbgri_offsetof(time_played),
     dbgri_offsetof(seek),
+    dbgri_offsetof(db_timestamp),
   };
 
 /* This list must be kept in sync with
@@ -1917,7 +1918,7 @@ db_build_query_group_albums(struct query_params *qp, struct query_clause *qc)
 			  "  g.id, g.persistentid, f.album, f.album_sort, COUNT(f.id) as track_count, " \
 			  "  1 as album_count, f.album_artist, f.songartistid, " \
 			  "  SUM(f.song_length), MIN(f.data_kind), MIN(f.media_kind), MAX(f.year), MAX(f.date_released), " \
-			  "  MAX(f.time_added), MAX(f.time_played), MAX(f.seek) " \
+			  "  MAX(f.time_added), MAX(f.time_played), MAX(f.seek), MAX(f.db_timestamp) " \
 			  "FROM files f JOIN groups g ON f.songalbumid = g.persistentid %s " \
 			  "GROUP BY f.songalbumid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
 
@@ -1935,7 +1936,7 @@ db_build_query_group_artists(struct query_params *qp, struct query_clause *qc)
 			  "  g.id, g.persistentid, f.album_artist, f.album_artist_sort, COUNT(f.id) as track_count, " \
 			  "  COUNT(DISTINCT f.songalbumid) as album_count, f.album_artist, f.songartistid, " \
 			  "  SUM(f.song_length), MIN(f.data_kind), MIN(f.media_kind), MAX(f.year), MAX(f.date_released), " \
-			  "  MAX(f.time_added), MAX(f.time_played), MAX(f.seek) " \
+			  "  MAX(f.time_added), MAX(f.time_played), MAX(f.seek), MAX(f.db_timestamp) " \
 			  "FROM files f JOIN groups g ON f.songartistid = g.persistentid %s " \
 			  "GROUP BY f.songartistid %s %s %s;",
 			  qc->where, qc->having, qc->order, qc->index);

--- a/src/db.c
+++ b/src/db.c
@@ -2718,6 +2718,13 @@ db_file_ping_bymatch(const char *path, int isdir)
 #undef Q_TMPL_NODIR
 }
 
+void
+db_file_artwork_ping_bymatch(const char *path)
+{
+  db_file_ping_bymatch(path, 1);
+  db_admin_setint64(DB_ADMIN_DB_UPDATE, (int64_t) time(NULL));
+}
+
 char *
 db_file_path_byid(int id)
 {

--- a/src/db.h
+++ b/src/db.h
@@ -304,6 +304,7 @@ struct group_info {
   uint32_t time_added;
   uint32_t time_played;
   uint32_t seek;
+  uint32_t db_timestamp;
 };
 
 #define gri_offsetof(field) offsetof(struct group_info, field)
@@ -325,6 +326,7 @@ struct db_group_info {
   char *time_added;
   char *time_played;
   char *seek;
+  char *db_timestamp;
 };
 
 #define dbgri_offsetof(field) offsetof(struct db_group_info, field)

--- a/src/db.h
+++ b/src/db.h
@@ -620,6 +620,9 @@ db_file_ping_bypath(const char *path, time_t mtime_max);
 void
 db_file_ping_bymatch(const char *path, int isdir);
 
+void
+db_file_artwork_ping_bymatch(const char *path);
+
 char *
 db_file_path_byid(int id);
 

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -213,7 +213,7 @@ artist_to_json(struct db_group_info *dbgri)
   if (ret < sizeof(uri))
     json_object_object_add(item, "uri", json_object_new_string(uri));
 
-  ret = snprintf(artwork_url, sizeof(artwork_url), "./artwork/group/%s", dbgri->id);
+  ret = snprintf(artwork_url, sizeof(artwork_url), "./artwork/group/%s?v=%s", dbgri->id, dbgri->db_timestamp);
   if (ret < sizeof(artwork_url))
     json_object_object_add(item, "artwork_url", json_object_new_string(artwork_url));
 
@@ -261,7 +261,7 @@ album_to_json(struct db_group_info *dbgri)
   if (ret < sizeof(uri))
     json_object_object_add(item, "uri", json_object_new_string(uri));
 
-  ret = snprintf(artwork_url, sizeof(artwork_url), "./artwork/group/%s", dbgri->id);
+  ret = snprintf(artwork_url, sizeof(artwork_url), "./artwork/group/%s?v=%s", dbgri->id, dbgri->db_timestamp);
   if (ret < sizeof(artwork_url))
     json_object_object_add(item, "artwork_url", json_object_new_string(artwork_url));
 

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -638,6 +638,20 @@ process_regular_file(const char *file, struct stat *sb, int type, int flags, int
   free_mfi(&mfi, 1);
 }
 
+static void
+process_artwork_file(const char *file, struct stat *sb, int type, int flags, int dir_id)
+{
+  char *path;
+  path = dirname(strdup(file));
+  db_file_artwork_ping_bymatch(path);
+  free(path);
+
+  cache_artwork_ping(file, sb->st_mtime, !(flags & F_SCAN_BULK));
+
+  // TODO [artworkcache] If entry in artwork cache exists for no artwork available for a album with files in the same directory, delete the entry
+
+}
+
 /* Thread: scan */
 static void
 process_file(char *file, struct stat *sb, enum file_type file_type, int scan_type, int flags, int dir_id)
@@ -673,10 +687,7 @@ process_file(char *file, struct stat *sb, enum file_type file_type, int scan_typ
 
       case FILE_ARTWORK:
 	DPRINTF(E_DBG, L_SCAN, "Artwork file: %s\n", file);
-	cache_artwork_ping(file, sb->st_mtime, !(flags & F_SCAN_BULK));
-
-	// TODO [artworkcache] If entry in artwork cache exists for no artwork available for a album with files in the same directory, delete the entry
-
+        process_artwork_file(file, sb, scan_type, flags, dir_id);
 	break;
 
       case FILE_CTRL_REMOTE:


### PR DESCRIPTION
Fixes #1168

To reproduce:
* add album, `foo`, with local artwork `cover.jpg`
* use web front end visit artist albums page, see artwork is as expected
* replace or delete local artwork for new album `foo`, wait up to 10second for cache to update 
* use web front end and navigate to search page and navigate back to artist albums page
* note that the artwork for album `foo` has not changed

The fix:
* `artwork_url` returned via json includes the `db_timestamp` for versioning/browser cache invalidation  for `album` grouping queries:  ie `/artwork/group/1234?v=1610834279`
* upon artwork file scan, update `db_timetamp` for album and mark db as updated
   * expects that the artwork file is in the same directory as the album tracks
   * `db updated` ensures (via json) browser will rerequest the album information and the `artwork_url`; ie `/artwork/group/1234?v=1610834509`
