### PR TITLE
[jsonapi] Get currently playing queue item details

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -548,7 +548,7 @@ GET /api/queue
 
 | Parameter       | Value                                                       |
 | --------------- | ----------------------------------------------------------- |
-| id              | *(Optional)* If a queue item id is given, only the item with the id will be returend. |
+| id              | *(Optional)* If a queue item id is given, only the item with the id will be returend. Use id=now_playing to get the currently playing item. |
 | start           | *(Optional)* If a `start`and an `end` position is given, only the items from `start` (included) to `end` (excluded) will be returned. If only a `start` position is given, only the item at this position will be returned. |
 | end             | *(Optional)* See `start` parameter |
 

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -2682,7 +2682,11 @@ jsonapi_reply_queue(struct httpd_request *hreq)
     query_params.sort = S_SHUFFLE_POS;
 
   param = evhttp_find_header(hreq->query, "id");
-  if (param && safe_atou32(param, &item_id) == 0)
+  if (param && strcmp(param, "now_playing") == 0)
+    {
+      query_params.filter = db_mprintf("id = %d", status.item_id);
+    }
+  else if (param && safe_atou32(param, &item_id) == 0)
     {
       query_params.filter = db_mprintf("id = %d", item_id);
     }


### PR DESCRIPTION
@cdlenfert this should make it possible to get the info with just one request. If you can test it is of course good, but it's a simple change, so I expect to merge it even if you can't.

Closes #1206 