### PR TITLE
Fixed potential crash on pulseaudio sink info callback, when an error occurs

### DIFF
--- a/src/outputs/pulse.c
+++ b/src/outputs/pulse.c
@@ -388,7 +388,7 @@ sinklist_cb(pa_context *ctx, const pa_sink_info *info, int eol, void *userdata)
   int i;
   int pos;
 
-  if (eol > 0)
+  if (eol > 0 || !info)
     return;
 
   DPRINTF(E_DBG, L_LAUDIO, "Callback for Pulseaudio sink '%s' (id %" PRIu32 ")\n", info->name, info->index);


### PR DESCRIPTION
I'm using Pulseaudio output with a speaker and a bluetooth headset. Sometimes when I turn of the bluetooth headset Pulseaudio creates an error and then the sinklist callback is called with a nullptr information structure. According to the [Pulseaudio documentation](https://freedesktop.org/software/pulseaudio/doxygen/introspect.html) this is valid call, and with this fix everything work as expected, even if the callback is called with a nullptr.