### PR TITLE
[scan]Add sort tags for ALAC

### DIFF
--- a/src/library/filescanner_ffmpeg.c
+++ b/src/library/filescanner_ffmpeg.c
@@ -164,6 +164,13 @@ static const struct metadata_map md_map_generic[] =
     { "album-sort",   0, mfi_offsetof(album_sort),         NULL },
     { "compilation",  1, mfi_offsetof(compilation),        NULL },
 
+    // ALAC sort tags
+    { "sort_name",           0, mfi_offsetof(title_sort),         NULL },
+    { "sort_artist",         0, mfi_offsetof(artist_sort),        NULL },
+    { "sort_album",          0, mfi_offsetof(album_sort),         NULL },
+    { "sort_album_artist",   0, mfi_offsetof(album_artist_sort),  NULL },
+    { "sort_composer",       0, mfi_offsetof(composer_sort),      NULL },
+
     // These tags are used to determine if files belong to a common compilation
     // or album, ref. https://picard.musicbrainz.org/docs/tags
     { "MusicBrainz Album Id",         1, mfi_offsetof(songalbumid), parse_albumid },


### PR DESCRIPTION
In the case of ALAC files, the name of the sort tags was reported by ffmpeg with a different name than the others.
I checked the ffmpeg source code and added the missing names.
https://github.com/FFmpeg/FFmpeg/blob/n4.4/libavformat/mov.c#L350

This is my first pull request, so please let me know if there are any mistakes.