### PR TITLE
[alsa] Fix ALSA devices icon

### DIFF
--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -1418,14 +1418,14 @@ alsa_init(void)
   alsa_cfg_secn = cfg_size(cfg, "alsa");
   if (alsa_cfg_secn == 0)
     {
-      alsa_device_add(cfg_audio, 0);
+      alsa_device_add(cfg_audio, 1);
     }
   else
     {
       for (i = 0; i < alsa_cfg_secn; ++i)
         {
           cfg_alsasec = cfg_getnsec(cfg, "alsa", i);
-          alsa_device_add(cfg_alsasec, i);
+          alsa_device_add(cfg_alsasec, i + 1);
         }
     }
 


### PR DESCRIPTION
I checked with Remote on my iPad.
As shown in the attached image, only one of the ALSA devices has a different icon.
![Remote_speaker_icon](https://user-images.githubusercontent.com/59403438/119082406-fa95fa80-ba38-11eb-85df-75eab11f82f6.png)

I couldn't find the exact specs, but I did find that it only changes when the Speaker id is 0.
I tested it for a while, but there doesn't seem to be anything wrong.