### PR TITLE
Add additional dependencies for systemd startup.

### DIFF
--- a/owntone.service.in
+++ b/owntone.service.in
@@ -1,7 +1,8 @@
 [Unit]
 Description=DAAP/DACP (iTunes), RSP and MPD server, supports AirPlay and Remote
 Documentation=man:owntone(8)
-After=network.target sound.target remote-fs.target pulseaudio.service avahi-daemon.service
+Requires=network.target local-fs.target avahi-daemon.socket
+After=network.target sound.target remote-fs.target pulseaudio.service
 
 [Service]
 ExecStart=@sbindir@/owntone -f


### PR DESCRIPTION
Particularly avahi-daemon is a pretty hard requirement of owntone; currently it's expected that the user has started/enabled the service rather than directly depending on it.