### PR TITLE
[smartpl] Add "comment" field to smartpl expression language

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -2547,6 +2547,7 @@ curl --include \
 | album_artist_id    | string   | Album artist id                           |
 | composer           | string   | Track composer                            |
 | genre              | string   | Genre                                     |
+| comment            | string   | Comment                                   |
 | year               | integer  | Release year                              |
 | track_number       | integer  | Track number                              |
 | disc_number        | integer  | Disc number                               |

--- a/README_SMARTPL.md
+++ b/README_SMARTPL.md
@@ -30,6 +30,7 @@ Where valid field-names (with their types) are:
 * `title` (string)
 * `genre` (string)
 * `composer` (string)
+* `comment` (string)
 * `path` (string)
 * `type` (string)
 * `grouping` (string)

--- a/src/SMARTPL.g
+++ b/src/SMARTPL.g
@@ -88,6 +88,7 @@ STRTAG		:	'artist'
 			|	'songartistid'
 			|	'songalbumid'
 			|	'codectype'
+			|	'comment'
 			;
 
 INTTAG		:	'play_count'

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -292,6 +292,7 @@ track_to_json(struct db_media_file_info *dbmfi)
   safe_json_add_string(item, "album_artist_id", dbmfi->songartistid);
   safe_json_add_string(item, "composer", dbmfi->composer);
   safe_json_add_string(item, "genre", dbmfi->genre);
+  safe_json_add_string(item, "comment", dbmfi->comment);
   safe_json_add_int_from_string(item, "year", dbmfi->year);
   safe_json_add_int_from_string(item, "track_number", dbmfi->track);
   safe_json_add_int_from_string(item, "disc_number", dbmfi->disc);


### PR DESCRIPTION
Fix #1213 by adding the "comment" field to the smart playlist expression language. The "comment" field is additionally exposed in the JSON API.