### PR TITLE
[spotify] Scan spotify podcast subscriptions into library

### DIFF
--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1232,6 +1232,7 @@ jsonapi_reply_spotify(struct httpd_request *hreq)
   spotify_status_get(&sp_status);
   json_object_object_add(jreply, "spotify_installed", json_object_new_boolean(sp_status.installed));
   json_object_object_add(jreply, "spotify_logged_in", json_object_new_boolean(sp_status.logged_in));
+  json_object_object_add(jreply, "has_podcast_support", json_object_new_boolean(sp_status.has_podcast_support));
   safe_json_add_string(jreply, "libspotify_user", sp_status.username);
 
   spotifywebapi_status_info_get(&webapi_info);

--- a/src/inputs/spotify.c
+++ b/src/inputs/spotify.c
@@ -144,3 +144,14 @@ spotify_status_get(struct spotify_status *status)
 
   backend->status_get(status);
 }
+
+bool
+spotify_podcast_support()
+{
+  struct spotify_backend *backend = backend_set();
+
+  if (!backend)
+    return false;
+
+  return backend->has_podcast_support;
+}

--- a/src/inputs/spotify.c
+++ b/src/inputs/spotify.c
@@ -144,14 +144,3 @@ spotify_status_get(struct spotify_status *status)
 
   backend->status_get(status);
 }
-
-bool
-spotify_podcast_support()
-{
-  struct spotify_backend *backend = backend_set();
-
-  if (!backend)
-    return false;
-
-  return backend->has_podcast_support;
-}

--- a/src/inputs/spotify.h
+++ b/src/inputs/spotify.h
@@ -9,6 +9,7 @@ struct spotify_status
   bool installed;
   bool logged_in;
   char username[128];
+  bool has_podcast_support;
 };
 
 struct spotify_backend
@@ -21,8 +22,6 @@ struct spotify_backend
   int (*relogin)(void);
   void (*uri_register)(const char *uri);
   void (*status_get)(struct spotify_status *status);
-
-  bool has_podcast_support;
 };
 
 int
@@ -48,8 +47,5 @@ spotify_uri_register(const char *uri);
 
 void
 spotify_status_get(struct spotify_status *status);
-
-bool
-spotify_podcast_support();
 
 #endif /* !__SPOTIFY_H__ */

--- a/src/inputs/spotify.h
+++ b/src/inputs/spotify.h
@@ -21,6 +21,8 @@ struct spotify_backend
   int (*relogin)(void);
   void (*uri_register)(const char *uri);
   void (*status_get)(struct spotify_status *status);
+
+  bool has_podcast_support;
 };
 
 int
@@ -46,5 +48,8 @@ spotify_uri_register(const char *uri);
 
 void
 spotify_status_get(struct spotify_status *status);
+
+bool
+spotify_podcast_support();
 
 #endif /* !__SPOTIFY_H__ */

--- a/src/inputs/spotify_librespotc.c
+++ b/src/inputs/spotify_librespotc.c
@@ -738,6 +738,7 @@ status_get(struct spotify_status *status)
   memcpy(status->username, ctx->status.username, sizeof(status->username));
   status->logged_in = ctx->status.logged_in;
   status->installed = true;
+  status->has_podcast_support = true;
 
   pthread_mutex_unlock(&ctx->lock);
 }
@@ -749,7 +750,5 @@ struct spotify_backend spotify_librespotc =
   .logout = logout,
   .relogin = relogin,
   .status_get = status_get,
-
-  .has_podcast_support = true,
 };
 

--- a/src/inputs/spotify_librespotc.c
+++ b/src/inputs/spotify_librespotc.c
@@ -749,5 +749,7 @@ struct spotify_backend spotify_librespotc =
   .logout = logout,
   .relogin = relogin,
   .status_get = status_get,
+
+  .has_podcast_support = true,
 };
 

--- a/src/inputs/spotify_libspotify.c
+++ b/src/inputs/spotify_libspotify.c
@@ -116,6 +116,7 @@ status_get(struct spotify_status *status)
 
   status->installed = info.libspotify_installed;
   status->logged_in = info.libspotify_logged_in;
+  status->has_podcast_support = false;
   snprintf(status->username, sizeof(status->username), "%s", info.libspotify_user);
 }
 
@@ -129,7 +130,5 @@ struct spotify_backend spotify_libspotify =
   .relogin = libspotify_relogin,
   .uri_register = libspotify_uri_register,
   .status_get = status_get,
-
-  .has_podcast_support = false,
 };
 

--- a/src/inputs/spotify_libspotify.c
+++ b/src/inputs/spotify_libspotify.c
@@ -129,5 +129,7 @@ struct spotify_backend spotify_libspotify =
   .relogin = libspotify_relogin,
   .uri_register = libspotify_uri_register,
   .status_get = status_get,
+
+  .has_podcast_support = false,
 };
 

--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -153,18 +153,18 @@ static const char *spotify_scope         = "playlist-read-private playlist-read-
 static const char *spotify_auth_uri      = "https://accounts.spotify.com/authorize";
 static const char *spotify_token_uri     = "https://accounts.spotify.com/api/token";
 
-static const char *spotify_playlist_uri	 = "https://api.spotify.com/v1/playlists/%s";
-static const char *spotify_track_uri     = "https://api.spotify.com/v1/tracks/%s";
-static const char *spotify_me_uri        = "https://api.spotify.com/v1/me";
-static const char *spotify_albums_uri    = "https://api.spotify.com/v1/me/albums?limit=50";
-static const char *spotify_album_uri = "https://api.spotify.com/v1/albums/%s";
-static const char *spotify_album_tracks_uri = "https://api.spotify.com/v1/albums/%s/tracks";
-static const char *spotify_playlists_uri = "https://api.spotify.com/v1/me/playlists?limit=50";
+static const char *spotify_playlist_uri	       = "https://api.spotify.com/v1/playlists/%s";
+static const char *spotify_track_uri           = "https://api.spotify.com/v1/tracks/%s";
+static const char *spotify_me_uri              = "https://api.spotify.com/v1/me";
+static const char *spotify_albums_uri          = "https://api.spotify.com/v1/me/albums?limit=50";
+static const char *spotify_album_uri           = "https://api.spotify.com/v1/albums/%s";
+static const char *spotify_album_tracks_uri    = "https://api.spotify.com/v1/albums/%s/tracks";
+static const char *spotify_playlists_uri       = "https://api.spotify.com/v1/me/playlists?limit=50";
 static const char *spotify_playlist_tracks_uri = "https://api.spotify.com/v1/playlists/%s/tracks";
-static const char *spotify_artist_albums_uri = "https://api.spotify.com/v1/artists/%s/albums?include_groups=album,single";
-static const char *spotify_shows_uri    = "https://api.spotify.com/v1/me/shows?limit=50";
-static const char *spotify_shows_episodes_uri = "https://api.spotify.com/v1/shows/%s/episodes";
-static const char *spotify_episode_uri     = "https://api.spotify.com/v1/episodes/%s";
+static const char *spotify_artist_albums_uri   = "https://api.spotify.com/v1/artists/%s/albums?include_groups=album,single";
+static const char *spotify_shows_uri           = "https://api.spotify.com/v1/me/shows?limit=50";
+static const char *spotify_shows_episodes_uri  = "https://api.spotify.com/v1/shows/%s/episodes";
+static const char *spotify_episode_uri         = "https://api.spotify.com/v1/episodes/%s";
 
 
 static enum spotify_item_type

--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -1989,6 +1989,7 @@ create_base_playlist(void)
 static void
 scan(enum spotify_request_type request_type)
 {
+  struct spotify_status sp_status;
   time_t start;
   time_t end;
 
@@ -2006,7 +2007,8 @@ scan(enum spotify_request_type request_type)
   create_saved_tracks_playlist();
   scan_saved_albums(request_type);
   scan_playlists(request_type);
-  if (spotify_podcast_support())
+  spotify_status_get(&sp_status);
+  if (sp_status.has_podcast_support)
     scan_saved_shows(request_type);
 
   scanning = false;


### PR DESCRIPTION
This PR implements scanning saved Spotify podcasts (shows) into the library (fixes #1274).
Spotify podcasts require the new Spotify input implementation.

@ejurgensen I added a flag to `spotify_backend` struct that indicates if the input spotify implementation supports playing podcasts. Please let me know if there is a better way to get this information.

There is room for improvements:

- ~~Artwork is not displayed for shows/episodes~~
- Information if an episode has been fully played is not mapped into our library (same applies for resume point)
- Show and episode descriptions are not mapped into our library
- Through the OwnTone Web API it is not possible to play a show/episode that is not scanned into the library
- Spotify search results for in the web interface for shows/episodes would also be nice

(Depending on how much time I have available I'll add them to this PR or will create new ones) 