### PR TITLE
Easier installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,10 +29,6 @@ sudo apt-get install \
 Note that OwnTone will also work with other versions and flavours of
 libgcrypt and libcurl, so the above are just suggestions.
 
-While OwnTone will work with versions of libevent between 2.0.0 and 2.1.3,
-it is recommended to use 2.1.4+. Otherwise you may not have support for
-simultaneous streaming to multiple DAAP clients.
-
 Optional packages:
 
  Feature              | Configure argument       | Packages

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,16 +29,22 @@ sudo apt-get install \
 Note that OwnTone will also work with other versions and flavours of
 libgcrypt and libcurl, so the above are just suggestions.
 
-Optional packages:
+The following features require extra packages, and that you add a configure
+argument when you run ./configure:
 
  Feature              | Configure argument       | Packages
- ---------------------|--------------------------|------------------------------------------------
- Chromecast           | `--enable-chromecast`    | libgnutls*-dev libprotobuf-c-dev
- Spotify (built-in)   | `--disable-spotify`      | libprotobuf-c-dev
+ ---------------------|--------------------------|-------------------------------------
+ Chromecast           | `--enable-chromecast`    | libgnutls*-dev
  Spotify (libspotify) | `--enable-libspotify`    | libspotify-dev
- Player web UI        | `--disable-webinterface` | libwebsockets-dev
- Live web UI          | `--with-libwebsockets`   | libwebsockets-dev
  Pulseaudio           | `--with-pulseaudio`      | libpulse-dev
+
+These features can be disabled saving you package dependencies:
+
+ Feature              | Configure argument       | Packages
+ ---------------------|--------------------------|-------------------------------------
+ Spotify (built-in)   | `--disable-spotify`      | libprotobuf-c-dev
+ Player web UI        | `--disable-webinterface` | libwebsockets-dev
+ Live web UI          | `--without-libwebsockets`| libwebsockets-dev
 
 Then run the following (adding configure arguments for optional features):
 
@@ -46,15 +52,25 @@ Then run the following (adding configure arguments for optional features):
 git clone https://github.com/owntone/owntone-server.git
 cd owntone-server
 autoreconf -i
-./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var
+./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-install-user
 make
 sudo make install
 ```
 
-Finally, read the section [Long version - after installation
-](#Long-version---after-installation) in the bottom of this document, which
-describes configuration, setting up init scripts and adding a system user.
-Also see the [README.md](README.md) for usage information.
+Using `--enable-install-user` means that `make install` will also add system
+user and group for owntone.
+
+With the above configure arguments, a systemd service file will be installed to
+`/etc/systemd/system/owntone.service` so that the server will start on boot.
+Use `--disable-install-systemd` if you don't want that.
+
+Now edit `/etc/owntone.conf`. Note the guide at the top highlighting which
+settings that normally require modification.
+
+Start the server with `sudo systemctl start owntone` and check that it is
+running with `sudo systemctl status owntone`.
+
+See the [README.md](README.md) for usage information.
 
 ## Quick version for Fedora
 
@@ -89,29 +105,31 @@ Then run the following:
 
 ```bash
 autoreconf -i
-./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var
+./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-install-user
 make
 sudo make install
 ```
 
-Finally, read the section [Long version - after installation
-](#Long-version---after-installation) in the bottom of this document, which
-describes configuration, setting up init scripts and adding a system user.
-Also see the README for usage information.
+Using `--enable-install-user` means that `make install` will also add system
+user and group for owntone.
+
+With the above configure arguments, a systemd service file will be installed to
+`/etc/systemd/system/owntone.service` so that the server will start on boot.
+Use `--disable-install-systemd` if you don't want that.
+
+Now edit `/etc/owntone.conf`. Note the guide at the top highlighting which
+settings that normally require modification.
+
+Start the server with `sudo systemctl start owntone` and check that it is
+running with `sudo systemctl status owntone`.
+
+See the [README.md](README.md) for usage information.
 
 ## Quick version for FreeBSD
 
-You can use the ports framework to handle dependencies and build options, so
-the following is sufficient to build from source on FreeBSD:
-
-```sh
-cd /usr/ports/audio/forked-daapd
-make install
-```
-
-Otherwise, there is a script in the 'scripts' folder that will at least attempt
-to do all the work for you. And should the script not work for you,
-you can still look through it and use it as an installation guide.
+There is a script in the 'scripts' folder that will at least attempt to do all
+the work for you. And should the script not work for you, you can still look
+through it and use it as an installation guide.
 
 ## Quick version for macOS (using Homebrew)
 
@@ -121,9 +139,11 @@ all the steps that you need to execute:
 
 ## "Quick" version for macOS (using macports)
 
-Caution: macports requires many downloads and lots of time to install
-(and sometimes build) ports... you'll want a decent network connection
-and some patience!
+Caution:
+1) this approach may be out of date, consider using the Homebrew method above
+since it is continuously tested.
+2) macports requires many downloads and lots of time to install (and sometimes
+build) ports... you'll want a decent network connection and some patience!
 
 Install macports (which requires Xcode):
   https://www.macports.org/install.php
@@ -236,8 +256,8 @@ Libraries:
   from <http://avahi.org/>
 - sqlite3 3.5.0+ with unlock notify API enabled (read below)  
   from <http://sqlite.org/download.html>
-- libav 9+ or ffmpeg 0.11+  
-  from <http://libav.org/> or <http://ffmpeg.org/>
+- ffmpeg (libav)
+  from <http://ffmpeg.org/>
 - libconfuse  
   from <http://www.nongnu.org/confuse/>
 - libevent 2.0+ (best with 2.1.4+)  
@@ -279,10 +299,6 @@ always the case in binary packages, so you may need to rebuild sqlite3 to
 enable the unlock notify API (you can check for the presence of the
 sqlite3_unlock_notify symbol in the sqlite3 library). Refer to the sqlite3
 documentation, look for `SQLITE_ENABLE_UNLOCK_NOTIFY`.
-
-libav (or ffmpeg) is a central piece of OwnTone and most other FLOSS
-multimedia applications. The version of libav you use will potentially have a
-great influence on your experience with OwnTone.
 
 ## Long version - building and installing
 
@@ -351,10 +367,17 @@ present (with headers). Use `--without-pulseaudio` to disable.
 Recommended build settings:
 
 ```bash
-./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var
+./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-install-user
 ```
 
 After configure run the usual make, and if that went well, `sudo make install`.
+
+With the above configure arguments, a systemd service file will be installed to
+`/etc/systemd/system/owntone.service` so that the server will start on boot.
+Use `--disable-install-systemd` if you don't want that.
+
+Using `--enable-install-user` means that `make install` will also add a system
+user and group for owntone.
 
 You may see two kinds of warnings during make.
 First, `/usr/bin/antlr3` may generate a long series of warnings that
@@ -375,59 +398,15 @@ RSPLexer.c:2674:16: warning: unused variable `_type' [-Wunused-variable]
 
 You can safely ignore all of these warnings.
 
-## Long version - after installation
-
 After installation:
 
 - edit the configuration file, `/etc/owntone.conf`
 - make sure the Avahi daemon is installed and running (Debian:
   `apt install avahi-daemon`)
 
-Note that `sudo make install` will not install any system files to start the
-service after boot, and it will not setup a system user.
+OwnTone will drop privileges to any user you specify in the configuration file
+if it's started as root.
 
-OwnTone will drop privileges to any user you'll specify in the
-configuration file if it's started as root.
+This user must have read permission to your library and read/write permissions
+to the database location (`$localstatedir/cache/owntone` by default).
 
-This user must have read permission on your library (you can create a group for
-this and make the user a member of the group, for instance) and read/write
-permissions on the database location (`$localstatedir/cache/owntone` by
-default).
-
-If your system uses systemd then you might be able to use the service file
-included, see `owntone.service`.
-
-Otherwise you might need an init script to start OwnTone at boot. A simple
-init script will do, OwnTone daemonizes all by itself and creates a
-pidfile under `/var/run`. Different distributions have different standards for
-init scripts and some do not use init scripts anymore; check the documentation
-for your distribution.
-
-For dependency-based boot systems, here are the OwnTone dependencies:
-
-- local filesystems
-- network filesystems, if needed in your setup (library on NFS, ...)
-- networking
-- NTP
-- Avahi daemon
-
-The LSB header below sums it up:
-
-```bash
-### BEGIN INIT INFO
-# Provides:          owntone
-# Required-Start:    $local_fs $remote_fs $network $time
-# Required-Stop:     $local_fs $remote_fs $network $time
-# Should-Start:      avahi
-# Should-Stop:       avahi
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
-# Short-Description: DAAP/DACP (iTunes) server, support for AirPlay and Spotify
-# Description:       OwnTone is an iTunes-compatible media server for sharing
-#                    your media library over the local network with DAAP/DACP
-#                    clients like iTunes. Like iTunes, it can be controlled by
-#                    Apple Remote (and compatibles) and stream music directly to
-#                    AirPlay devices. It also supports streaming to RSP clients
-#                    (Roku devices) and streaming from Spotify.
-### END INIT INFO
-```

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,10 @@ RPM_SPEC_FILE = owntone.spec
 CONF_FILE = owntone.conf
 SYSTEMD_SERVICE_FILE = owntone.service
 
-sysconf_DATA = $(CONF_FILE)
+if COND_INSTALL_SYSTEMD
+systemddir = $(SYSTEMD_DIR)
+systemd_DATA = $(SYSTEMD_SERVICE_FILE)
+endif
 
 BUILT_SOURCES = $(CONF_FILE) $(SYSTEMD_SERVICE_FILE)
 
@@ -33,9 +36,34 @@ EXTRA_DIST = \
 	$(RPM_SPEC_FILE)
 
 install-data-hook:
-	$(MKDIR_P) "$(DESTDIR)$(localstatedir)/cache/$(PACKAGE)/libspotify"
 	$(MKDIR_P) "$(DESTDIR)$(localstatedir)/log"
 	$(MKDIR_P) "$(DESTDIR)$(localstatedir)/run"
+	$(MKDIR_P) "$(DESTDIR)$(localstatedir)/cache/$(PACKAGE)"
+if COND_INSTALL_USER
+	( $(GETENT) group $(OWNTONE_GROUP) &> /dev/null || $(GROUPADD) --system $(OWNTONE_GROUP) )
+	( $(GETENT) passwd $(OWNTONE_USER) &> /dev/null || $(USERADD) --system --no-create-home --gid $(OWNTONE_GROUP) --groups audio --shell /usr/sbin/nologin $(OWNTONE_USER) )
+	( ! $(GETENT) group pulse-access &> /dev/null || $(USERMOD) --append --groups pulse-access $(OWNTONE_USER) )
+	$(CHOWN) $(OWNTONE_USER).$(OWNTONE_GROUP) "$(DESTDIR)$(localstatedir)/cache/$(PACKAGE)"
+endif
+if COND_LIBSPOTIFY
+	$(MKDIR_P) "$(DESTDIR)$(localstatedir)/cache/$(PACKAGE)/libspotify"
+endif
+# we do this manually instead of using sysconf_DATA because it overwrites existing config
+if COND_INSTALL_CONF_FILE
+	$(MKDIR_P) "$(DESTDIR)$(sysconfdir)"
+	[ -f $(DESTDIR)$(sysconfdir)/$(CONF_FILE) ] || $(INSTALL_DATA) $(CONF_FILE) $(DESTDIR)$(sysconfdir)/$(CONF_FILE)
+endif
+
+uninstall-hook:
+	( cd "$(DESTDIR)$(localstatedir)/cache" && rm -rf $(PACKAGE) )
+	( cd "$(DESTDIR)$(localstatedir)/log" && rm -f "$(PACKAGE).log*" )
+	( cd "$(DESTDIR)$(localstatedir)/run" && rm -f "$(PACKAGE).pid" )
+if COND_INSTALL_USER
+	( ! $(GETENT) passwd $(OWNTONE_USER) &> /dev/null || $(USERDEL) $(OWNTONE_USER) )
+endif
+if COND_INSTALL_CONF_FILE
+	( cd "$(DESTDIR)$(sysconfdir)" && rm -f $(CONF_FILE) )
+endif
 
 CLEANFILES = $(BUILT_SOURCES)
 

--- a/configure.ac
+++ b/configure.ac
@@ -350,26 +350,54 @@ OWNTONE_ARG_DISABLE([MPD client protocol support], [mpd], [MPD])
 AM_CONDITIONAL([COND_MPD], [[test "x$enable_mpd" = "xyes"]])
 
 dnl Include default webinterface
-OWNTONE_ARG_DISABLE([Include default web interface], [webinterface], [WEBINTERFACE],
+OWNTONE_ARG_DISABLE([include default web interface], [webinterface], [WEBINTERFACE],
 	[AS_IF([[test "x$with_libwebsockets" = "xno"]],
 		[AC_MSG_ERROR([[Web interface requires libwebsockets >= 2.0.2 (or use --disable-webinterface)]])])
 	])
 AM_CONDITIONAL([COND_WEBINTERFACE], [[test "x$enable_webinterface" = "xyes"]])
 
-dnl Defining users and groups
+dnl Creating and defining users and groups
+OWNTONE_ARG_ENABLE([having 'make install' add user/group and 'make uninstall' delete], [install_user], [INSTALL_USER],
+	[AC_PATH_PROG([GETENT], [[getent]], [], [$PATH$PATH_SEPARATOR/usr/sbin])
+	 AC_PATH_PROG([USERADD], [[useradd]], [], [$PATH$PATH_SEPARATOR/usr/sbin])
+	 AC_PATH_PROG([USERDEL], [[userdel]], [], [$PATH$PATH_SEPARATOR/usr/sbin])
+	 AC_PATH_PROG([USERMOD], [[usermod]], [], [$PATH$PATH_SEPARATOR/usr/sbin])
+	 AC_PATH_PROG([GROUPADD], [[groupadd]], [], [$PATH$PATH_SEPARATOR/usr/sbin])
+	 AC_PATH_PROG([CHOWN], [[chown]], [], [$PATH$PATH_SEPARATOR/usr/sbin])
+	 AS_IF([[test -z "$GETENT" -o -z "$USERADD" -o -z "$USERDEL" -o -z "$USERMOD" -o -z "$GROUPADD" -o -z "$CHOWN"]],
+		[AC_MSG_ERROR([[Required program for --enable-install-user not found]])])
+	])
+AM_CONDITIONAL([COND_INSTALL_USER], [[test "x$enable_install_user" = "xyes"]])
+
 AC_ARG_WITH([owntone_user],
-	[AS_HELP_STRING([--with-user=USER],
-		[User for running OwnTone (default=owntone)])],
+	[AS_HELP_STRING([--with-user=USER], [User for running OwnTone (default=owntone)])],
 	[[test x"$withval" = xyes && withval=]], [[withval=]])
 OWNTONE_USER=${withval:-owntone}
 AC_SUBST([OWNTONE_USER])
 
 AC_ARG_WITH([owntone_group],
-	[AS_HELP_STRING([--with-group=GROUP],
-		[Group for owntone user (default=USER)])],
+	[AS_HELP_STRING([--with-group=GROUP], [Group for owntone user (default=USER)])],
 	[[test x"$withval" = xyes && withval=]], [[withval=]])
 OWNTONE_GROUP=${withval:-$OWNTONE_USER}
 AC_SUBST([OWNTONE_GROUP])
+
+dnl Install config file
+OWNTONE_ARG_DISABLE([install configuration file], [install_conf_file], [INSTALL_CONF_FILE])
+AM_CONDITIONAL([COND_INSTALL_CONF_FILE], [[test "x$enable_install_conf_file" = "xyes"]])
+
+# Service files are not installed like https://www.freedesktop.org/software/systemd/man/daemon.html
+# instructs, because that means they go to /lib/systemd/system (the destination
+# for package service files!) instead of /usr/local/etc/systemd/system with a
+# default ./configure, and I don't want that on my machine. Also, the suggested
+# approach is incredibly ugly.
+OWNTONE_ARG_DISABLE([install systemd service file], [install_systemd], [INSTALL_SYSTEMD])
+AM_CONDITIONAL([COND_INSTALL_SYSTEMD], [[test "x$enable_install_systemd" = "xyes"]])
+AC_ARG_WITH([systemddir],
+	[AS_HELP_STRING([--with-systemddir=DIR], [Directory for systemd service files (default=SYSCONFDIR/systemd/system)])],
+	[[test x"$withval" = xyes && withval=]], [[withval=]])
+SYSTEMD_DIR=${withval:-$sysconfdir/systemd/system}
+AC_SUBST([SYSTEMD_DIR])
+
 dnl --- End options ---
 
 dnl Unconditional since we always want to produce Makefiles for dist targets

--- a/scripts/freebsd_install.sh
+++ b/scripts/freebsd_install.sh
@@ -89,14 +89,10 @@ if [ "$yn" = "y" ]; then
 
 	export CFLAGS="-march=native -g -I/usr/local/include -I/usr/include"
 	export LDFLAGS="-L/usr/local/lib -L/usr/lib"
-	./configure && gmake
+	./configure --disable-install-systemd && gmake
 
 	read -p "Should the script install owntone and add service startup scripts? [y/N] " yn
 	if [ "$yn" = "y" ]; then
-		if [ -f $CONFIG ]; then
-			echo "Backing up old config file to $CONFIG.bak"
-			sudo cp "$CONFIG" "$CONFIG.bak"
-		fi
 		sudo gmake install
 
 		sudo sed -i -- 's/\/var\/cache/\/usr\/local\/var\/cache/g' $CONFIG


### PR DESCRIPTION
Easier install by letting 'make install' add user and service files
    
If --enable-install-user set add owntone system user and group (unless other user/group specified with --with-user or --with-group). The user will be added to pulse-access if the group is present.
    
Don't overwrite config, it's a pita. Use same solution as shairport-sync where distros can use --disable-install_conf_file if required.
    
A './configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var' will result in service files in /etc/systemd/system, which seems sensible. Package builds can specify other location, e.g. --with-systemdir=/lib/systemd/system, or ship their own service file and use --disable-install-systemd.
    
Also added more cleanup on uninstall - before we where leaving stuff in /var/cache/owntone + the logs + the pid files.