### PR TITLE
[db] add 'flag' to files and queue tables

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -791,7 +791,7 @@ curl -X PUT "http://localhost:3689/api/queue/items/2"
 | GET       | [/api/library/albums/{id}/tracks](#list-album-tracks)       | Get list of tracks for an album      |
 | GET       | [/api/library/tracks/{id}](#get-a-track)                    | Get a track                          |
 | GET       | [/api/library/tracks/{id}/playlists](#list-playlists-for-a-track) | Get list of playlists for a track |
-| PUT       | [/api/library/tracks/{id}](#update-track-properties)        | Update a tracks properties (rating, play_count) |
+| PUT       | [/api/library/tracks/{id}](#update-track-properties)        | Update a tracks properties (rating, play_count,usermark) |
 | GET       | [/api/library/genres](#list-genres)                         | Get list of genres                   |
 | GET       | [/api/library/count](#get-count-of-tracks-artists-and-albums) | Get count of tracks, artists and albums |
 | GET       | [/api/library/files](#list-local-directories)               | Get list of directories in the local library    |
@@ -1528,6 +1528,7 @@ curl -X GET "http://localhost:3689/api/library/track/1"
   "disc_number": 1,
   "length_ms": 223170,
   "rating": 0,
+  "usermark": 0,
   "play_count": 0,
   "skip_count": 0,
   "time_added": "2019-01-20T11:58:29Z",
@@ -1601,7 +1602,7 @@ curl -X GET "http://localhost:3689/api/library/tracks/27/playlists"
 
 ### Update track properties
 
-Change properties of a specific track (supported properties are "rating" and "play_count")
+Change properties of a specific track (supported properties are "rating", "play_count" and "usermark")
 
 **Endpoint**
 
@@ -1621,6 +1622,7 @@ PUT /api/library/tracks/{id}
 | --------------- | ----------------------------------------------------------- |
 | rating          | The new rating (0 - 100)                                    |
 | play_count      | Either `increment` or `reset`. `increment` will increment `play_count` and update `time_played`, `reset` will set `play_count` and `skip_count` to zero and delete `time_played` and `time_skipped` |
+| usermark        | The new usermark (>= 0)                                     |
 
 
 **Response**
@@ -2565,6 +2567,7 @@ curl --include \
 | path               | string   | Path                                      |
 | uri                | string   | Resource identifier                       |
 | artwork_url        | string   | *(optional)* [Artwork url](#artwork-urls) |
+| usermark           | integer  | User review marking of track (ranges from 0) |
 
 
 ### `paging` object

--- a/src/SMARTPL.g
+++ b/src/SMARTPL.g
@@ -102,6 +102,7 @@ INTTAG		:	'play_count'
 			|	'bits_per_sample'
 			|	'samplerate'
 			|	'song_length'
+			|	'flag'
 			;
 
 DATETAG		:	'time_added'

--- a/src/SMARTPL.g
+++ b/src/SMARTPL.g
@@ -102,7 +102,7 @@ INTTAG		:	'play_count'
 			|	'bits_per_sample'
 			|	'samplerate'
 			|	'song_length'
-			|	'flag'
+			|	'usermark'
 			;
 
 DATETAG		:	'time_added'

--- a/src/db.c
+++ b/src/db.c
@@ -3324,6 +3324,27 @@ db_file_rating_update_byvirtualpath(const char *virtual_path, uint32_t rating)
 #undef Q_TMPL
 }
 
+int
+db_file_flag_update_byid(uint32_t id, uint32_t flag)
+{
+#define Q_TMPL "UPDATE files SET flag = %d WHERE id = %d;"
+  char *query;
+  int ret;
+
+  query = sqlite3_mprintf(Q_TMPL, flag, id);
+
+  ret = db_query_run(query, 1, 0);
+
+  if (ret == 0)
+    {
+      db_admin_setint64(DB_ADMIN_DB_MODIFIED, (int64_t) time(NULL));
+      listener_notify(LISTENER_RATING);
+    }
+
+  return ((ret < 0) ? -1 : sqlite3_changes(hdl));
+#undef Q_TMPL
+}
+
 void
 db_file_delete_bypath(const char *path)
 {

--- a/src/db.c
+++ b/src/db.c
@@ -227,6 +227,7 @@ static const struct col_type_map mfi_cols_map[] =
     { "album_artist_sort",  mfi_offsetof(album_artist_sort),  DB_TYPE_STRING, DB_FIXUP_ALBUM_ARTIST_SORT },
     { "composer_sort",      mfi_offsetof(composer_sort),      DB_TYPE_STRING, DB_FIXUP_COMPOSER_SORT },
     { "channels",           mfi_offsetof(channels),           DB_TYPE_INT },
+    { "flag",               mfi_offsetof(flag),               DB_TYPE_INT },
   };
 
 /* This list must be kept in sync with
@@ -294,6 +295,7 @@ static const struct col_type_map qi_cols_map[] =
     { "bitrate",            qi_offsetof(bitrate),             DB_TYPE_INT },
     { "samplerate",         qi_offsetof(samplerate),          DB_TYPE_INT },
     { "channels",           qi_offsetof(channels),            DB_TYPE_INT },
+    { "flag",               qi_offsetof(flag),                DB_TYPE_INT },
   };
 
 /* This list must be kept in sync with
@@ -365,6 +367,7 @@ static const ssize_t dbmfi_cols_map[] =
     dbmfi_offsetof(album_artist_sort),
     dbmfi_offsetof(composer_sort),
     dbmfi_offsetof(channels),
+    dbmfi_offsetof(flag),
   };
 
 /* This list must be kept in sync with
@@ -453,6 +456,7 @@ static const struct qi_mfi_map qi_mfi_map[] =
     { qi_offsetof(bitrate),             mfi_offsetof(bitrate),             dbmfi_offsetof(bitrate) },
     { qi_offsetof(samplerate),          mfi_offsetof(samplerate),          dbmfi_offsetof(samplerate) },
     { qi_offsetof(channels),            mfi_offsetof(channels),            dbmfi_offsetof(channels) },
+    { qi_offsetof(flag),                mfi_offsetof(flag),                dbmfi_offsetof(flag) },
   };
 
 /* This list must be kept in sync with

--- a/src/db.c
+++ b/src/db.c
@@ -295,7 +295,6 @@ static const struct col_type_map qi_cols_map[] =
     { "bitrate",            qi_offsetof(bitrate),             DB_TYPE_INT },
     { "samplerate",         qi_offsetof(samplerate),          DB_TYPE_INT },
     { "channels",           qi_offsetof(channels),            DB_TYPE_INT },
-    { "usermark",           qi_offsetof(usermark),            DB_TYPE_INT },
   };
 
 /* This list must be kept in sync with
@@ -456,7 +455,6 @@ static const struct qi_mfi_map qi_mfi_map[] =
     { qi_offsetof(bitrate),             mfi_offsetof(bitrate),             dbmfi_offsetof(bitrate) },
     { qi_offsetof(samplerate),          mfi_offsetof(samplerate),          dbmfi_offsetof(samplerate) },
     { qi_offsetof(channels),            mfi_offsetof(channels),            dbmfi_offsetof(channels) },
-    { qi_offsetof(usermark),            mfi_offsetof(usermark),            dbmfi_offsetof(usermark) },
   };
 
 /* This list must be kept in sync with

--- a/src/db.c
+++ b/src/db.c
@@ -227,7 +227,7 @@ static const struct col_type_map mfi_cols_map[] =
     { "album_artist_sort",  mfi_offsetof(album_artist_sort),  DB_TYPE_STRING, DB_FIXUP_ALBUM_ARTIST_SORT },
     { "composer_sort",      mfi_offsetof(composer_sort),      DB_TYPE_STRING, DB_FIXUP_COMPOSER_SORT },
     { "channels",           mfi_offsetof(channels),           DB_TYPE_INT },
-    { "flag",               mfi_offsetof(flag),               DB_TYPE_INT },
+    { "usermark",           mfi_offsetof(usermark),           DB_TYPE_INT },
   };
 
 /* This list must be kept in sync with
@@ -295,7 +295,7 @@ static const struct col_type_map qi_cols_map[] =
     { "bitrate",            qi_offsetof(bitrate),             DB_TYPE_INT },
     { "samplerate",         qi_offsetof(samplerate),          DB_TYPE_INT },
     { "channels",           qi_offsetof(channels),            DB_TYPE_INT },
-    { "flag",               qi_offsetof(flag),                DB_TYPE_INT },
+    { "usermark",           qi_offsetof(usermark),            DB_TYPE_INT },
   };
 
 /* This list must be kept in sync with
@@ -367,7 +367,7 @@ static const ssize_t dbmfi_cols_map[] =
     dbmfi_offsetof(album_artist_sort),
     dbmfi_offsetof(composer_sort),
     dbmfi_offsetof(channels),
-    dbmfi_offsetof(flag),
+    dbmfi_offsetof(usermark),
   };
 
 /* This list must be kept in sync with
@@ -456,7 +456,7 @@ static const struct qi_mfi_map qi_mfi_map[] =
     { qi_offsetof(bitrate),             mfi_offsetof(bitrate),             dbmfi_offsetof(bitrate) },
     { qi_offsetof(samplerate),          mfi_offsetof(samplerate),          dbmfi_offsetof(samplerate) },
     { qi_offsetof(channels),            mfi_offsetof(channels),            dbmfi_offsetof(channels) },
-    { qi_offsetof(flag),                mfi_offsetof(flag),                dbmfi_offsetof(flag) },
+    { qi_offsetof(usermark),            mfi_offsetof(usermark),            dbmfi_offsetof(usermark) },
   };
 
 /* This list must be kept in sync with
@@ -3325,20 +3325,20 @@ db_file_rating_update_byvirtualpath(const char *virtual_path, uint32_t rating)
 }
 
 int
-db_file_flag_update_byid(uint32_t id, uint32_t flag)
+db_file_usermark_update_byid(uint32_t id, uint32_t usermark)
 {
-#define Q_TMPL "UPDATE files SET flag = %d WHERE id = %d;"
+#define Q_TMPL "UPDATE files SET usermark = %d WHERE id = %d;"
   char *query;
   int ret;
 
-  query = sqlite3_mprintf(Q_TMPL, flag, id);
+  query = sqlite3_mprintf(Q_TMPL, usermark, id);
 
   ret = db_query_run(query, 1, 0);
 
   if (ret == 0)
     {
       db_admin_setint64(DB_ADMIN_DB_MODIFIED, (int64_t) time(NULL));
-      listener_notify(LISTENER_RATING);
+      listener_notify(LISTENER_UPDATE);
     }
 
   return ((ret < 0) ? -1 : sqlite3_changes(hdl));

--- a/src/db.h
+++ b/src/db.h
@@ -150,8 +150,6 @@ enum user_mark {
   USER_MARK_REVIEW = 4
 };
 
-#define DB_FILES_USERMARK_MAX  UINT_MAX
-
 
 /* Note that fields marked as integers in the metadata map in filescanner_ffmpeg must be uint32_t here */
 struct media_file_info {

--- a/src/db.h
+++ b/src/db.h
@@ -141,6 +141,13 @@ enum data_kind {
 const char *
 db_data_kind_label(enum data_kind data_kind);
 
+enum flag_kind {
+  FLAG_KIND_NA = 0,     // unset
+  FLAG_KIND_DELETE = 1, // delete
+
+  FLAG_KIND_MAX         // unused
+};
+
 /* Note that fields marked as integers in the metadata map in filescanner_ffmpeg must be uint32_t here */
 struct media_file_info {
   uint32_t id;
@@ -654,6 +661,9 @@ db_file_seek_update(int id, uint32_t seek);
 
 int
 db_file_rating_update_byid(uint32_t id, uint32_t rating);
+
+int
+db_file_flag_update_byid(uint32_t id, uint32_t rating);
 
 int
 db_file_rating_update_byvirtualpath(const char *virtual_path, uint32_t rating);

--- a/src/db.h
+++ b/src/db.h
@@ -141,11 +141,15 @@ enum data_kind {
 const char *
 db_data_kind_label(enum data_kind data_kind);
 
+
+/* Indicates user marked status on a track */
 enum flag_kind {
   FLAG_KIND_NA = 0,     // unset
-  FLAG_KIND_DELETE = 1, // delete
+  FLAG_KIND_DELETE,
+  FLAG_KIND_REXCODE,
+  FLAG_KIND_REVIEW,
 
-  FLAG_KIND_MAX         // unused
+  FLAG_KIND_MAX         // unused - keep last in enum
 };
 
 /* Note that fields marked as integers in the metadata map in filescanner_ffmpeg must be uint32_t here */
@@ -205,7 +209,7 @@ struct media_file_info {
   uint32_t time_skipped;
 
   int64_t disabled;      // Long because it stores up to INOTIFY_FAKE_COOKIE
-  uint32_t flag;
+  uint32_t flag;         // See enum flag_kind { }
 
   uint64_t sample_count; //TODO [unused] sample count is never set and therefor always 0
   char *codectype;       /* song.codectype, 4 chars max (32 bits) */

--- a/src/db.h
+++ b/src/db.h
@@ -514,8 +514,6 @@ struct db_queue_item {
 
   int64_t songartistid;
 
-  uint32_t usermark;
-
   /* Not saved in queue table */
   uint32_t seek;
 };

--- a/src/db.h
+++ b/src/db.h
@@ -142,15 +142,16 @@ const char *
 db_data_kind_label(enum data_kind data_kind);
 
 
-/* Indicates user marked status on a track */
-enum flag_kind {
-  FLAG_KIND_NA = 0,     // unset
-  FLAG_KIND_DELETE,
-  FLAG_KIND_REXCODE,
-  FLAG_KIND_REVIEW,
-
-  FLAG_KIND_MAX         // unused - keep last in enum
+/* Indicates user marked status on a track  - values can be bitwise enumerated */
+enum user_mark {
+  USER_MARK_NA  = 0,
+  USER_MARK_DELETE = 1,
+  USER_MARK_REXCODE = 2,
+  USER_MARK_REVIEW = 4
 };
+
+#define DB_FILES_USERMARK_MAX  UINT_MAX
+
 
 /* Note that fields marked as integers in the metadata map in filescanner_ffmpeg must be uint32_t here */
 struct media_file_info {
@@ -209,7 +210,7 @@ struct media_file_info {
   uint32_t time_skipped;
 
   int64_t disabled;      // Long because it stores up to INOTIFY_FAKE_COOKIE
-  uint32_t flag;         // See enum flag_kind { }
+  uint32_t usermark;     // See enum user_mark { }
 
   uint64_t sample_count; //TODO [unused] sample count is never set and therefor always 0
   char *codectype;       /* song.codectype, 4 chars max (32 bits) */
@@ -405,7 +406,7 @@ struct db_media_file_info {
   char *album_artist_sort;
   char *composer_sort;
   char *channels;
-  char *flag;
+  char *usermark;
 };
 
 #define dbmfi_offsetof(field) offsetof(struct db_media_file_info, field)
@@ -515,7 +516,7 @@ struct db_queue_item {
 
   int64_t songartistid;
 
-  uint32_t flag;
+  uint32_t usermark;
 
   /* Not saved in queue table */
   uint32_t seek;
@@ -667,7 +668,7 @@ int
 db_file_rating_update_byid(uint32_t id, uint32_t rating);
 
 int
-db_file_flag_update_byid(uint32_t id, uint32_t rating);
+db_file_usermark_update_byid(uint32_t id, uint32_t usermark);
 
 int
 db_file_rating_update_byvirtualpath(const char *virtual_path, uint32_t rating);

--- a/src/db.h
+++ b/src/db.h
@@ -198,6 +198,7 @@ struct media_file_info {
   uint32_t time_skipped;
 
   int64_t disabled;      // Long because it stores up to INOTIFY_FAKE_COOKIE
+  uint32_t flag;
 
   uint64_t sample_count; //TODO [unused] sample count is never set and therefor always 0
   char *codectype;       /* song.codectype, 4 chars max (32 bits) */
@@ -393,6 +394,7 @@ struct db_media_file_info {
   char *album_artist_sort;
   char *composer_sort;
   char *channels;
+  char *flag;
 };
 
 #define dbmfi_offsetof(field) offsetof(struct db_media_file_info, field)
@@ -501,6 +503,8 @@ struct db_queue_item {
   uint32_t channels;
 
   int64_t songartistid;
+
+  uint32_t flag;
 
   /* Not saved in queue table */
   uint32_t seek;

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -96,7 +96,8 @@
   "   album_sort         VARCHAR(1024) DEFAULT NULL COLLATE DAAP,"	\
   "   album_artist_sort  VARCHAR(1024) DEFAULT NULL COLLATE DAAP,"	\
   "   composer_sort      VARCHAR(1024) DEFAULT NULL COLLATE DAAP,"	\
-  "   channels           INTEGER DEFAULT 0"		\
+  "   channels           INTEGER DEFAULT 0,"		\
+  "   flag               INTEGER DEFAULT 0"		\
   ");"
 
 #define T_PL					\
@@ -199,7 +200,8 @@
   "   type                VARCHAR(8) DEFAULT NULL,"			\
   "   bitrate             INTEGER DEFAULT 0,"				\
   "   samplerate          INTEGER DEFAULT 0,"				\
-  "   channels            INTEGER DEFAULT 0"				\
+  "   channels            INTEGER DEFAULT 0,"				\
+  "   flag                INTEGER DEFAULT 0"				\
   ");"
 
 #define Q_PL1								\

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -97,7 +97,7 @@
   "   album_artist_sort  VARCHAR(1024) DEFAULT NULL COLLATE DAAP,"	\
   "   composer_sort      VARCHAR(1024) DEFAULT NULL COLLATE DAAP,"	\
   "   channels           INTEGER DEFAULT 0,"		\
-  "   flag               INTEGER DEFAULT 0"		\
+  "   usermark           INTEGER DEFAULT 0"		\
   ");"
 
 #define T_PL					\
@@ -201,7 +201,7 @@
   "   bitrate             INTEGER DEFAULT 0,"				\
   "   samplerate          INTEGER DEFAULT 0,"				\
   "   channels            INTEGER DEFAULT 0,"				\
-  "   flag                INTEGER DEFAULT 0"				\
+  "   usermark            INTEGER DEFAULT 0"				\
   ");"
 
 #define Q_PL1								\

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -200,8 +200,7 @@
   "   type                VARCHAR(8) DEFAULT NULL,"			\
   "   bitrate             INTEGER DEFAULT 0,"				\
   "   samplerate          INTEGER DEFAULT 0,"				\
-  "   channels            INTEGER DEFAULT 0,"				\
-  "   usermark            INTEGER DEFAULT 0"				\
+  "   channels            INTEGER DEFAULT 0"				\
   ");"
 
 #define Q_PL1								\

--- a/src/db_init.h
+++ b/src/db_init.h
@@ -26,7 +26,7 @@
  * is a major upgrade. In other words minor version upgrades permit downgrading
  * the server after the database was upgraded. */
 #define SCHEMA_VERSION_MAJOR 21
-#define SCHEMA_VERSION_MINOR 06
+#define SCHEMA_VERSION_MINOR 07
 
 int
 db_init_indices(sqlite3 *hdl);

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1161,17 +1161,17 @@ static const struct db_upgrade_query db_upgrade_v2106_queries[] =
   };
 
 /* ---------------------------- 21.06 -> 21.07 ------------------------------ */
-#define U_v2107_ALTER_FILES_PENDING_DELETE \
-  "ALTER TABLE files ADD COLUMN flag INTEGER DEFAULT 0;"
-#define U_v2107_ALTER_QUEUE_PENDING_DELETE \
-  "ALTER TABLE queue ADD COLUMN flag INTEGER DEFAULT 0;"
+#define U_v2107_ALTER_FILES_USERMARK \
+  "ALTER TABLE files ADD COLUMN usermark INTEGER DEFAULT 0;"
+#define U_v2107_ALTER_QUEUE_USERMARK \
+  "ALTER TABLE queue ADD COLUMN usermark INTEGER DEFAULT 0;"
 #define U_v2107_SCVER_MINOR                    \
   "UPDATE admin SET value = '07' WHERE key = 'schema_version_minor';"
 
 static const struct db_upgrade_query db_upgrade_v2107_queries[] =
   {
-    { U_v2107_ALTER_FILES_PENDING_DELETE, "update files adding flag" },
-    { U_v2107_ALTER_QUEUE_PENDING_DELETE, "update queue adding flag" },
+    { U_v2107_ALTER_FILES_USERMARK, "update files adding usermark" },
+    { U_v2107_ALTER_QUEUE_USERMARK, "update queue adding usermark" },
 
     { U_v2107_SCVER_MINOR,    "set schema_version_minor to 07" },
   };

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1163,15 +1163,12 @@ static const struct db_upgrade_query db_upgrade_v2106_queries[] =
 /* ---------------------------- 21.06 -> 21.07 ------------------------------ */
 #define U_v2107_ALTER_FILES_USERMARK \
   "ALTER TABLE files ADD COLUMN usermark INTEGER DEFAULT 0;"
-#define U_v2107_ALTER_QUEUE_USERMARK \
-  "ALTER TABLE queue ADD COLUMN usermark INTEGER DEFAULT 0;"
 #define U_v2107_SCVER_MINOR                    \
   "UPDATE admin SET value = '07' WHERE key = 'schema_version_minor';"
 
 static const struct db_upgrade_query db_upgrade_v2107_queries[] =
   {
     { U_v2107_ALTER_FILES_USERMARK, "update files adding usermark" },
-    { U_v2107_ALTER_QUEUE_USERMARK, "update queue adding usermark" },
 
     { U_v2107_SCVER_MINOR,    "set schema_version_minor to 07" },
   };

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1160,6 +1160,22 @@ static const struct db_upgrade_query db_upgrade_v2106_queries[] =
     { U_v2106_SCVER_MINOR,    "set schema_version_minor to 06" },
   };
 
+/* ---------------------------- 21.06 -> 21.07 ------------------------------ */
+#define U_v2107_ALTER_FILES_PENDING_DELETE \
+  "ALTER TABLE files ADD COLUMN flag INTEGER DEFAULT 0;"
+#define U_v2107_ALTER_QUEUE_PENDING_DELETE \
+  "ALTER TABLE queue ADD COLUMN flag INTEGER DEFAULT 0;"
+#define U_v2107_SCVER_MINOR                    \
+  "UPDATE admin SET value = '07' WHERE key = 'schema_version_minor';"
+
+static const struct db_upgrade_query db_upgrade_v2107_queries[] =
+  {
+    { U_v2107_ALTER_FILES_PENDING_DELETE, "update files adding flag" },
+    { U_v2107_ALTER_QUEUE_PENDING_DELETE, "update queue adding flag" },
+
+    { U_v2107_SCVER_MINOR,    "set schema_version_minor to 07" },
+  };
+
 
 /* -------------------------- Main upgrade handler -------------------------- */
 
@@ -1354,6 +1370,13 @@ db_upgrade(sqlite3 *hdl, int db_ver)
 	return -1;
 
       ret = db_generic_upgrade(hdl, db_upgrade_v2106_queries, ARRAY_SIZE(db_upgrade_v2106_queries));
+      if (ret < 0)
+	return -1;
+
+      /* FALLTHROUGH */
+
+    case 2106:
+      ret = db_generic_upgrade(hdl, db_upgrade_v2107_queries, ARRAY_SIZE(db_upgrade_v2107_queries));
       if (ret < 0)
 	return -1;
 

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -3351,10 +3351,7 @@ jsonapi_reply_library_tracks_put_byid(struct httpd_request *hreq)
       if (ret < 0)
 	return HTTP_BADREQUEST;
 
-      if (uval >= 0 && uval <= DB_FILES_USERMARK_MAX)
-        ret = db_file_usermark_update_byid(track_id, uval);
-      else
-        DPRINTF(E_WARN, L_WEB, "Ignoring invalid usermark value '%u' for track '%d'.\n", uval, track_id);
+      ret = db_file_usermark_update_byid(track_id, uval);
 
       if (ret < 0)
         return HTTP_INTERNAL;

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -2222,7 +2222,6 @@ queue_item_to_json(struct db_queue_item *queue_item, char shuffle)
   json_object_object_add(item, "bitrate", json_object_new_int(queue_item->bitrate));
   json_object_object_add(item, "samplerate", json_object_new_int(queue_item->samplerate));
   json_object_object_add(item, "channels", json_object_new_int(queue_item->channels));
-  json_object_object_add(item, "usermark", json_object_new_int(queue_item->usermark));
 
   return item;
 }

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -3299,8 +3299,7 @@ jsonapi_reply_library_tracks_put_byid(struct httpd_request *hreq)
 {
   int track_id;
   const char *param;
-  int val;
-  uint32_t uval;
+  uint32_t val;
   int ret;
 
   ret = safe_atoi32(hreq->uri_parsed->path_parts[3], &track_id);
@@ -3329,7 +3328,7 @@ jsonapi_reply_library_tracks_put_byid(struct httpd_request *hreq)
   param = evhttp_find_header(hreq->query, "rating");
   if (param)
     {
-      ret = safe_atoi32(param, &val);
+      ret = safe_atou32(param, &val);
       if (ret < 0)
 	return HTTP_BADREQUEST;
 
@@ -3347,11 +3346,11 @@ jsonapi_reply_library_tracks_put_byid(struct httpd_request *hreq)
   param = evhttp_find_header(hreq->query, "usermark");
   if (param)
     {
-      ret = safe_atou32(param, &uval);
+      ret = safe_atou32(param, &val);
       if (ret < 0)
 	return HTTP_BADREQUEST;
 
-      ret = db_file_usermark_update_byid(track_id, uval);
+      ret = db_file_usermark_update_byid(track_id, val);
 
       if (ret < 0)
         return HTTP_INTERNAL;


### PR DESCRIPTION
implements https://github.com/owntone/owntone-server/issues/1306

Add `flag` to `files` and `queue` tables to support user _marking_ of tracks for the purpose of maintanence/review (outside of the server).

For instance, user adds many tracks to server without reviewing tracks but may find that they don't like and wish to remove; in normal situation user would need to note the track, find the corresponding file in library and then detele.  Having a flag in db that marks a track (for future implementation in web ui in `now playing` page/modal) for review helps automate this use case.

Tracks are marked via `PUT` on `http://<server>:3689/api/library/tracks/1234?flag=1`
Tracks are identified via `GET` on `http://<server>:3689/api/search/type=tracks&expression=review+>+0` which will provide the `path` of the underlying library track(s)