### PR TITLE
[web-src] now playing modal setting track's usermark review status

### DIFF
--- a/web-src/src/components/ListItemTrack.vue
+++ b/web-src/src/components/ListItemTrack.vue
@@ -4,7 +4,7 @@
       <slot name="icon"></slot>
     </figure>
     <div class="media-content fd-has-action is-clipped" @click="listeners.click">
-      <h1 class="title is-6" :class="{ 'has-text-grey': props.track.media_kind === 'podcast' && props.track.play_count > 0 }">{{ props.track.title }}</h1>
+      <h1 class="title is-6" :class="{ 'has-text-grey': props.track.usermark > 0 || props.track.media_kind === 'podcast' && props.track.play_count > 0, 'is-italic': props.track.usermark > 0 }">{{ props.track.title }}</h1>
       <h2 class="subtitle is-7 has-text-grey"><b>{{ props.track.artist }}</b></h2>
       <h2 class="subtitle is-7 has-text-grey">{{ props.track.album }}</h2>
       <slot name="progress"></slot>

--- a/web-src/src/components/ListTracks.vue
+++ b/web-src/src/components/ListTracks.vue
@@ -7,7 +7,7 @@
         </a>
       </template>
     </list-item-track>
-    <modal-dialog-track :show="show_details_modal" :track="selected_track" @close="show_details_modal = false" />
+    <modal-dialog-track :show="show_details_modal" :track="selected_track" @close="show_details_modal = false" @usermark-updated="usermark_upd" />
   </div>
 </template>
 
@@ -38,6 +38,10 @@ export default {
       } else {
         webapi.player_play_uri(track.uri, false)
       }
+    },
+
+    usermark_upd: function (args) {
+      this.$emit('usermark-updated', args)
     },
 
     open_dialog: function (track) {

--- a/web-src/src/components/ModalDialogQueueItem.vue
+++ b/web-src/src/components/ModalDialogQueueItem.vue
@@ -60,6 +60,16 @@
                     <span v-if="item.bitrate"> | {{ item.bitrate }} Kb/s</span>
                   </span>
                 </p>
+                <p>
+                  <span class="heading">Usermark</span>
+                  <span class="title is-6">{{ this.usermark }}</span>
+                </p>
+                <div class="buttons">
+                  <a class="button is-small is-danger" @click="usermark_update(1)">Mark to delete</a>
+                  <a class="button is-small is-warning" @click="usermark_update(2)">Mark to rexcode</a>
+                  <a class="button is-small is-warning" @click="usermark_update(4)">Mark to review</a>
+                  <a v-if="this.usermark > 0" class="button is-small is-success" @click="usermark_update(0)">Mark reset</a>
+                </div>
               </div>
             </div>
             <footer class="card-footer">
@@ -88,6 +98,7 @@ export default {
 
   data () {
     return {
+      usermark: -1,
       spotify_track: {}
     }
   },
@@ -129,6 +140,20 @@ export default {
     open_spotify_album: function () {
       this.$emit('close')
       this.$router.push({ path: '/music/spotify/albums/' + this.spotify_track.album.id })
+    },
+
+    usermark_update (value) {
+      const newvalue = value === 0 ? 0 : value | this.usermark
+      webapi.library_track_set_usermark(this.track_id, newvalue).then(() => {
+        this.usermark = newvalue
+      })
+    }
+  },
+
+  computed: {
+    track_id () {
+      const item = this.$store.state.queue.items.find((elem) => elem.id === this.item.id)
+      return (item === undefined) ? -1 : item.track_id
     }
   },
 
@@ -142,6 +167,11 @@ export default {
         })
       } else {
         this.spotify_track = {}
+        webapi.library_track(this.track_id).then((response) => {
+          this.usermark = response.data.usermark
+        }).catch(() => {
+          this.usermark = -1
+        })
       }
     }
   }

--- a/web-src/src/components/ModalDialogQueueItem.vue
+++ b/web-src/src/components/ModalDialogQueueItem.vue
@@ -65,10 +65,10 @@
                   <span class="title is-6">{{ this.usermark }}</span>
                 </p>
                 <div class="buttons">
-                  <a class="button is-small is-danger" @click="usermark_update(1)">Mark to delete</a>
-                  <a class="button is-small is-warning" @click="usermark_update(2)">Mark to rexcode</a>
-                  <a class="button is-small is-warning" @click="usermark_update(4)">Mark to review</a>
-                  <a v-if="this.usermark > 0" class="button is-small is-success" @click="usermark_update(0)">Mark reset</a>
+                  <a :disabled="this.usermark_is_set(1)" class="button is-small is-danger" @click="usermark_update(1)">Mark to delete</a>
+                  <a :disabled="this.usermark_is_set(2)" class="button is-small is-warning" @click="usermark_update(2)">Mark to rexcode</a>
+                  <a :disabled="this.usermark_is_set(4)" class="button is-small is-warning" @click="usermark_update(4)">Mark to review</a>
+                  <a :disabled="this.usermark === 0" class="button is-small is-success" @click="usermark_update(0)">Mark reset</a>
                 </div>
               </div>
             </div>
@@ -140,6 +140,10 @@ export default {
     open_spotify_album: function () {
       this.$emit('close')
       this.$router.push({ path: '/music/spotify/albums/' + this.spotify_track.album.id })
+    },
+
+    usermark_is_set: function (value) {
+      return (this.usermark & value) > 0
     },
 
     usermark_update (value) {

--- a/web-src/src/components/ModalDialogTrack.vue
+++ b/web-src/src/components/ModalDialogTrack.vue
@@ -180,6 +180,7 @@ export default {
       const newvalue = value === 0 ? 0 : value | this.usermark
       webapi.library_track_set_usermark(this.track.id, newvalue).then(() => {
         this.usermark = newvalue
+        this.$emit('usermark-updated', { value: this.usermark, track_id: this.track.id })
       })
     },
 

--- a/web-src/src/pages/PageAlbum.vue
+++ b/web-src/src/pages/PageAlbum.vue
@@ -24,7 +24,7 @@
     </template>
     <template slot="content">
       <p class="heading is-7 has-text-centered-mobile fd-has-margin-top">{{ album.track_count }} tracks</p>
-      <list-tracks :tracks="tracks" :uris="album.uri"></list-tracks>
+      <list-tracks :tracks="tracks" :uris="album.uri" @usermark-updated="usermark_upd"></list-tracks>
       <modal-dialog-album :show="show_album_details_modal" :album="album" @close="show_album_details_modal = false" />
     </template>
   </content-with-hero>
@@ -70,6 +70,10 @@ export default {
     open_artist: function () {
       this.show_details_modal = false
       this.$router.push({ path: '/music/artists/' + this.album.artist_id })
+    },
+
+    usermark_upd: function (args) {
+      this.tracks.find(e => e.id === args.track_id).usermark = args.value
     },
 
     play: function () {

--- a/web-src/src/pages/PageArtistTracks.vue
+++ b/web-src/src/pages/PageArtistTracks.vue
@@ -19,8 +19,9 @@
       </template>
       <template slot="content">
         <p class="heading has-text-centered-mobile"><a class="has-text-link" @click="open_artist">{{ artist.album_count }} albums</a> | {{ artist.track_count }} tracks</p>
-        <list-tracks :tracks="tracks.items" :uris="track_uris"></list-tracks>
+        <list-tracks :tracks="tracks.items" :uris="track_uris" @usermark-updated="usermark_upd"></list-tracks>
         <modal-dialog-artist :show="show_artist_details_modal" :artist="artist" @close="show_artist_details_modal = false" />
+        <modal-dialog-track :show="show_details_modal" :track="selected_track" @close="show_details_modal = false" />
       </template>
     </content-with-heading>
   </div>
@@ -77,6 +78,10 @@ export default {
     open_artist: function () {
       this.show_details_modal = false
       this.$router.push({ path: '/music/artists/' + this.artist.id })
+    },
+
+    usermark_upd: function (args) {
+      this.tracks.items.find(e => e.id === args.track_id).usermark = args.value
     },
 
     play: function () {

--- a/web-src/src/pages/PageBrowse.vue
+++ b/web-src/src/pages/PageBrowse.vue
@@ -27,7 +27,7 @@
         <p class="heading">tracks</p>
       </template>
       <template slot="content">
-        <list-tracks :tracks="recently_played.items"></list-tracks>
+        <list-tracks :tracks="recently_played.items" @usermark-updated="usermark_upd_played"></list-tracks>
       </template>
       <template slot="footer">
         <nav class="level">
@@ -80,6 +80,10 @@ export default {
   methods: {
     open_browse: function (type) {
       this.$router.push({ path: '/music/browse/' + type })
+    },
+
+    usermark_upd_played: function (args) {
+      this.recently_played.items.find(e => e.id === args.track_id).usermark = args.value
     }
   }
 }

--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -28,7 +28,7 @@
       </div>
       <div class="fd-has-padding-left-right">
         <div class="container has-text-centered fd-has-margin-top">
-          <h1 class="title is-5">
+          <h1 :class="{ 'title': true, 'is-5': true, 'has-text-grey': this.usermark > 0, 'is-italic': this.usermark > 0}">
             {{ now_playing.title }}
           </h1>
           <h2 class="title is-6">
@@ -55,7 +55,7 @@
         </div>
       </div>
     </div>
-    <modal-dialog-queue-item :show="show_details_modal" :item="selected_item" @close="show_details_modal = false" />
+    <modal-dialog-queue-item :show="show_details_modal" :item="selected_item" :np_usermark="this.usermark" @close="show_details_modal = false" @close_usermark="close_usermark_upd"/>
   </section>
 </template>
 
@@ -74,6 +74,8 @@ export default {
     return {
       item_progress_ms: 0,
       interval_id: 0,
+
+      usermark: 0,
 
       show_details_modal: false,
       selected_item: {}
@@ -139,6 +141,11 @@ export default {
       })
     },
 
+    close_usermark_upd: function (args) {
+      this.usermark = args.value
+      this.show_details_modal = false
+    },
+
     open_dialog: function (item) {
       this.selected_item = item
       this.show_details_modal = true
@@ -155,6 +162,14 @@ export default {
       if (this.state.state === 'play') {
         this.interval_id = window.setInterval(this.tick, 1000)
       }
+    },
+
+    'now_playing' () {
+      webapi.library_track(this.now_playing.track_id).then((response) => {
+        this.usermark = response.data.usermark
+      }).catch(() => {
+        this.usermark = 0
+      })
     }
   }
 }

--- a/web-src/src/pages/PagePlaylist.vue
+++ b/web-src/src/pages/PagePlaylist.vue
@@ -15,7 +15,7 @@
     </template>
     <template slot="content">
       <p class="heading has-text-centered-mobile">{{ tracks.length }} tracks</p>
-      <list-tracks :tracks="tracks" :uris="uris"></list-tracks>
+      <list-tracks :tracks="tracks" :uris="uris" @usermark-updated="usermark_upd"></list-tracks>
       <modal-dialog-playlist :show="show_playlist_details_modal" :playlist="playlist" :uris="uris" @close="show_playlist_details_modal = false" />
     </template>
   </content-with-heading>
@@ -66,6 +66,10 @@ export default {
   },
 
   methods: {
+    usermark_upd: function (args) {
+      this.tracks.find(e => e.id === args.track_id).usermark = args.value
+    },
+
     play: function () {
       webapi.player_play_uri(this.uris, true)
     }

--- a/web-src/src/pages/PageSearch.vue
+++ b/web-src/src/pages/PageSearch.vue
@@ -34,7 +34,7 @@
         <p class="title is-4">Tracks</p>
       </template>
       <template slot="content">
-        <list-tracks :tracks="tracks.items"></list-tracks>
+        <list-tracks :tracks="tracks.items" @usermark-updated="usermark_upd"></list-tracks>
       </template>
       <template slot="footer">
         <nav v-if="show_all_tracks_button" class="level">
@@ -353,6 +353,10 @@ export default {
         }
       })
       this.$refs.search_field.blur()
+    },
+
+    usermark_upd: function (args) {
+      this.tracks.items.find(e => e.id === args.track_id).usermark = args.value
     },
 
     open_search_tracks: function () {

--- a/web-src/src/webapi/index.js
+++ b/web-src/src/webapi/index.js
@@ -335,6 +335,13 @@ export default {
     return axios.put('./api/library/tracks/' + trackId, undefined, { params: attributes })
   },
 
+  library_track_set_usermark (trackId, flag) {
+    return axios.put('/api/library/tracks/' + trackId, undefined, { params: { usermark: flag } }).then((response) => {
+      store.dispatch('add_notification', { text: flag === 0 ? 'Track Review Reset' : 'Track Review Updated', type: flag === 0 ? 'success' : 'info', timeout: 1500 })
+      return Promise.resolve(response)
+    })
+  },
+
   library_files (directory = undefined) {
     const filesParams = { directory: directory }
     return axios.get('./api/library/files', {


### PR DESCRIPTION
Implement web ui functionality to allow user mark tracks for review as #1309 via the _queue item modal_ and also _track item modal_.  Track listings on the various pages will give an indication that a track has been marked with title in italics and now reactive when update been made (closure of modal) without reloading tracks.

![usermark](https://user-images.githubusercontent.com/18466811/133884637-9b8e0cd8-dbf4-4f43-a4c8-772b6bb2c8d9.png)
![albumtracks](https://user-images.githubusercontent.com/18466811/135317997-5d24cce8-95b7-437a-b6a6-c35d0e4341cf.png)


cc @chme 