### PR TITLE
[web-src] podcast handling of propogated 'play_count_changed' event

### DIFF
--- a/web-src/src/components/ListAlbums.vue
+++ b/web-src/src/components/ListAlbums.vue
@@ -52,6 +52,7 @@
         :album="selected_album"
         :media_kind="media_kind"
         @remove-podcast="open_remove_podcast_dialog()"
+        @play-count-changed="play_count_changed()"
         @close="show_details_modal = false" />
     <modal-dialog
         :show="show_remove_podcast_modal"
@@ -143,6 +144,10 @@ export default {
           this.show_details_modal = false
         })
       })
+    },
+
+    play_count_changed: function () {
+      this.$emit('play-count-changed')
     },
 
     remove_podcast: function () {


### PR DESCRIPTION
On the `podcast` page, when you mark a podcast as played (using the album modal) the unplayed tracks for that RSS, on the podcast page, are not updated because there is a missing propogation of the `play_count_changed` event.
![podcasts](https://user-images.githubusercontent.com/18466811/135499707-3a5d71d7-ea54-4c68-a54d-603eb3f9b576.png)
* elipsis on CGP Grey podcast, "mark as played"
* the podcast episodes at the top of screen for podcast should disappear
   * currently they don't due to the missing event propogation

Simply fix to propogate

cc @chme 