### PR TITLE
Podcasts manual update

### DIFF
--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -4358,6 +4358,13 @@ jsonapi_reply_library_backup(struct httpd_request *hreq)
   return HTTP_OK;
 }
 
+extern struct library_source rssscanner;
+static int
+jsonapi_reply_update_rss(struct httpd_request *hreq)
+{
+  rssscanner.rescan();
+  return HTTP_OK;
+}
 
 static struct httpd_uri_map adm_handlers[] =
   {
@@ -4370,6 +4377,7 @@ static struct httpd_uri_map adm_handlers[] =
     { EVHTTP_REQ_GET,    "^/api/library$",                               jsonapi_reply_library },
     { EVHTTP_REQ_GET |
       EVHTTP_REQ_PUT,    "^/api/update$",                                jsonapi_reply_update },
+    { EVHTTP_REQ_PUT,    "^/api/update/rss$",                            jsonapi_reply_update_rss },
     { EVHTTP_REQ_PUT,    "^/api/rescan$",                                jsonapi_reply_meta_rescan },
     { EVHTTP_REQ_POST,   "^/api/spotify-login$",                         jsonapi_reply_spotify_login },
     { EVHTTP_REQ_GET,    "^/api/spotify-logout$",                        jsonapi_reply_spotify_logout },

--- a/web-src/src/pages/PagePodcasts.vue
+++ b/web-src/src/pages/PagePodcasts.vue
@@ -43,6 +43,12 @@
       </template>
       <template slot="heading-right">
         <div class="buttons is-centered">
+          <a class="button is-small" v-if='albums.items.length > 0' @click="update_podcasts">
+            <span class="icon">
+              <i class="mdi mdi-rss"></i>
+            </span>
+            <span>Update</span>
+          </a>
           <a class="button is-small" @click="open_add_podcast_dialog">
             <span class="icon">
               <i class="mdi mdi-rss"></i>
@@ -133,11 +139,34 @@ export default {
       })
     },
 
+    update_podcasts: function () {
+      webapi.library_podcast_update()
+    },
+
     reload_podcasts: function () {
       webapi.library_albums('podcast').then(({ data }) => {
         this.albums = data
         this.reload_new_episodes()
       })
+    }
+  },
+
+  computed: {
+    podcasts_tracks () {
+      return this.$store.state.podcasts_count.tracks
+    },
+    podcasts () {
+      return this.$store.state.podcasts_count
+    }
+  },
+
+  watch: {
+    'podcasts' () {
+      this.reload_podcasts()
+    },
+
+    'podcasts_tracks' () {
+      this.reload_new_episodes()
     }
   }
 }

--- a/web-src/src/webapi/index.js
+++ b/web-src/src/webapi/index.js
@@ -299,6 +299,10 @@ export default {
     })
   },
 
+  library_podcast_update () {
+    return axios.put('/api/update/rss')
+  },
+
   library_add (url) {
     return axios.post('./api/library/add', undefined, { params: { url: url } })
   },


### PR DESCRIPTION
Enable functionality on web ui `podcasts` page for manual RSS refresh - this can be useful to override the servers own non-configurable refresh period.

New button on page to force request - uses existing notifiers to know async refresh has complete and update page.
![Screenshot from 2021-10-03 16-38-26](https://user-images.githubusercontent.com/18466811/135761226-ed1c9200-2796-4215-aff9-98669873b810.png)
