### PR TITLE
Get SPEC file to build with 28.2 and FC35

### DIFF
--- a/owntone.spec.in
+++ b/owntone.spec.in
@@ -18,7 +18,7 @@ Release: 1%{?dist}
 License: GPLv2+
 Group: Applications/Multimedia
 Url: https://github.com/owntone/owntone-server
-Source0: https://github.com/owntone/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+Source0: https://github.com/owntone/%{name}/archive/%{version}/%{name}-%{version}.tar.xz
 %{?systemd_ordering}
 BuildRequires: gcc, make, systemd, pkgconfig, libunistring-devel
 BuildRequires: pkgconfig(zlib), pkgconfig(libconfuse), pkgconfig(mxml)
@@ -30,6 +30,7 @@ BuildRequires: pkgconfig(libswscale), pkgconfig(libavutil)
 BuildRequires: pkgconfig(libavfilter), pkgconfig(libcurl)
 BuildRequires: pkgconfig(openssl), pkgconfig(libwebsockets) > 2.0.2
 BuildRequires: pkgconfig(libsodium), pkgconfig(avahi-client) >= 0.6.24
+BuildRequires: pkgconfig(libprotobuf-c)
 # pkgconfig(libplist) not used universally, so require libplist-devel instead
 BuildRequires: libplist-devel >= 0.16
 Requires(pre): shadow-utils
@@ -43,7 +44,6 @@ BuildRequires: pkgconfig(libpulse)
 BuildRequires: libspotify-devel
 %endif
 %if %{with chromecast}
-BuildRequires: pkgconfig(libprotobuf-c)
 BuildRequires: pkgconfig(gnutls)
 %endif
 
@@ -113,8 +113,14 @@ exit 0
 %attr(0750,%{username},%{groupname}) %{homedir}
 %ghost %{_localstatedir}/log/%{name}.log
 %{_mandir}/man?/*
+%exclude /etc/systemd/system/%{name}.service
 
 %changelog
+* Mon Nov 22 2021 Derek Atkins <derek@ihtfp.com> - 28.2-1
+   - Release tarball is a XZ not GZ file
+   - Configure always needs protobuf-c, not just for chromecast
+   - Exclude build-system-installed service file and use system location
+
 * Sat Mar 17 2018 Scott Shambarger <devel@shambarger.net> - 26.0-1
    - 26.0 release.
    - Update spec file to handle new feature defaults.

--- a/owntone.spec.in
+++ b/owntone.spec.in
@@ -69,10 +69,9 @@ by iTunes and friends to share/stream media libraries over the network.
 %build
 %configure \
   --with%{!?with_alsa:out}-alsa --with%{!?with_pulseaudio:out}-pulseaudio \
-  --with-libcurl --with-libwebsockets --with-libsodium --with-libplist \
-  --with-avahi %{?with_spotify:--enable-spotify} \
+  --with-libwebsockets --with-avahi %{?with_spotify:--enable-spotify} \
   %{?with_lastfm:--enable-lastfm} %{?with_chromecast:--enable-chromecast} \
-  --with-daapd-user=%{username} --with-daapd-group=%{groupname}
+  --with-user=%{username} --with-group=%{groupname}
 %make_build
 
 %install

--- a/owntone.spec.in
+++ b/owntone.spec.in
@@ -65,7 +65,8 @@ by iTunes and friends to share/stream media libraries over the network.
 %configure \
   --with%{!?with_alsa:out}-alsa --with%{!?with_pulseaudio:out}-pulseaudio \
   --with-libwebsockets --with-avahi %{?with_chromecast:--enable-chromecast} \
-  --with-user=%{username} --with-group=%{groupname} --disable-install_systemd
+  --with-user=%{username} --with-group=%{groupname} \
+  --with-systemddir=%{_unitdir}
 %make_build
 
 %install
@@ -74,8 +75,6 @@ rm -f %{buildroot}%{_pkgdocdir}/INSTALL
 mkdir -p %{buildroot}%{homedir}
 mkdir -p %{buildroot}%{_localstatedir}/log
 touch %{buildroot}%{_localstatedir}/log/%{name}.log
-mkdir -p %{buildroot}%{_unitdir}
-install -m 0644 owntone.service %{buildroot}%{_unitdir}/%{name}.service
 rm -f %{buildroot}%{_libdir}/%{name}/*.la
 
 %pre

--- a/owntone.spec.in
+++ b/owntone.spec.in
@@ -46,6 +46,7 @@ BuildRequires: libspotify-devel
 %if %{with chromecast}
 BuildRequires: pkgconfig(gnutls)
 %endif
+Requires: avahi
 
 %global homedir %{_localstatedir}/lib/%{name}
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}

--- a/owntone.spec.in
+++ b/owntone.spec.in
@@ -65,7 +65,7 @@ by iTunes and friends to share/stream media libraries over the network.
 %configure \
   --with%{!?with_alsa:out}-alsa --with%{!?with_pulseaudio:out}-pulseaudio \
   --with-libwebsockets --with-avahi %{?with_chromecast:--enable-chromecast} \
-  --with-user=%{username} --with-group=%{groupname}
+  --with-user=%{username} --with-group=%{groupname} --disable-install_systemd
 %make_build
 
 %install
@@ -107,7 +107,6 @@ exit 0
 %attr(0750,%{username},%{groupname}) %{homedir}
 %ghost %{_localstatedir}/log/%{name}.log
 %{_mandir}/man?/*
-%exclude /etc/systemd/system/%{name}.service
 
 %changelog
 * Mon Nov 22 2021 Derek Atkins <derek@ihtfp.com> - 28.2-1

--- a/owntone.spec.in
+++ b/owntone.spec.in
@@ -5,8 +5,6 @@
 
 %bcond_without alsa
 %bcond_without pulseaudio
-%bcond_with spotify
-%bcond_with lastfm
 %bcond_with chromecast
 
 %global _hardened_build 1
@@ -40,9 +38,6 @@ BuildRequires: pkgconfig(alsa)
 %if %{with pulseaudio}
 BuildRequires: pkgconfig(libpulse)
 %endif
-%if %{with spotify}
-BuildRequires: libspotify-devel
-%endif
 %if %{with chromecast}
 BuildRequires: pkgconfig(gnutls)
 %endif
@@ -69,8 +64,7 @@ by iTunes and friends to share/stream media libraries over the network.
 %build
 %configure \
   --with%{!?with_alsa:out}-alsa --with%{!?with_pulseaudio:out}-pulseaudio \
-  --with-libwebsockets --with-avahi %{?with_spotify:--enable-spotify} \
-  %{?with_lastfm:--enable-lastfm} %{?with_chromecast:--enable-chromecast} \
+  --with-libwebsockets --with-avahi %{?with_chromecast:--enable-chromecast} \
   --with-user=%{username} --with-group=%{groupname}
 %make_build
 


### PR DESCRIPTION
This PR gets the SPEC file to work properly with the release tarball.  Specifically, I needed to:

* Change the Source tarball from GZ to XZ
* always depend on protobuf-c (configure exits if it's not found, even without chromecast)
* the build system installed owntone.service into /etc, which is wrong.  Exclude that location and use the correct location.

With these changes, the RPM builds on FC35.