### PR TITLE
Add a SystemD template service for owntone

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,10 +70,6 @@ settings that normally require modification.
 Start the server with `sudo systemctl start owntone` and check that it is
 running with `sudo systemctl status owntone`.
 
-You can start or enable the service for a "zone" by `sudo systemctl
-start owntone@zone` and check that it is running with `sudo systemctl
-status owntone@zone`.
-
 See the [README.md](README.md) for usage information.
 
 ## Quick version for Fedora
@@ -126,10 +122,6 @@ settings that normally require modification.
 
 Start the server with `sudo systemctl start owntone` and check that it is
 running with `sudo systemctl status owntone`.
-
-You can start or enable the service for a "zone" by `sudo systemctl
-start owntone@zone` and check that it is running with `sudo systemctl
-status owntone@zone`.
 
 See the [README.md](README.md) for usage information.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,6 +70,10 @@ settings that normally require modification.
 Start the server with `sudo systemctl start owntone` and check that it is
 running with `sudo systemctl status owntone`.
 
+You can start or enable the service for a "zone" by `sudo systemctl
+start owntone@zone` and check that it is running with `sudo systemctl
+status owntone@zone`.
+
 See the [README.md](README.md) for usage information.
 
 ## Quick version for Fedora
@@ -122,6 +126,10 @@ settings that normally require modification.
 
 Start the server with `sudo systemctl start owntone` and check that it is
 running with `sudo systemctl status owntone`.
+
+You can start or enable the service for a "zone" by `sudo systemctl
+start owntone@zone` and check that it is running with `sudo systemctl
+status owntone@zone`.
 
 See the [README.md](README.md) for usage information.
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,13 +7,14 @@ ACLOCAL_AMFLAGS = -I m4
 RPM_SPEC_FILE = owntone.spec
 CONF_FILE = owntone.conf
 SYSTEMD_SERVICE_FILE = owntone.service
+SYSTEMD_TSERVICE_FILE = owntone@.service
 
 if COND_INSTALL_SYSTEMD
 systemddir = $(SYSTEMD_DIR)
-systemd_DATA = $(SYSTEMD_SERVICE_FILE)
+systemd_DATA = $(SYSTEMD_SERVICE_FILE) $(SYSTEMD_TSERVICE_FILE)
 endif
 
-BUILT_SOURCES = $(CONF_FILE) $(SYSTEMD_SERVICE_FILE)
+BUILT_SOURCES = $(CONF_FILE) $(SYSTEMD_SERVICE_FILE) $(SYSTEMD_TSERVICE_FILE)
 
 SUBDIRS = $(LIBRESPOTC_SUBDIR) sqlext src htdocs
 
@@ -33,6 +34,7 @@ nobase_dist_doc_DATA = \
 EXTRA_DIST = \
 	$(CONF_FILE).in \
 	$(SYSTEMD_SERVICE_FILE).in \
+	$(SYSTEMD_TSERVICE_FILE).in \
 	$(RPM_SPEC_FILE)
 
 install-data-hook:
@@ -73,7 +75,7 @@ do_subst = $(SED) -e 's|@sbindir[@]|$(sbindir)|g' \
              -e 's|@OWNTONE_USER[@]|$(OWNTONE_USER)|g'
 
 # these files use $prefix, which is determined at build (not configure) time
-$(CONF_FILE) $(SYSTEMD_SERVICE_FILE): Makefile
+$(CONF_FILE) $(SYSTEMD_SERVICE_FILE) $(SYSTEMD_TSERVICE_FILE): Makefile
 	$(AM_V_at)rm -f $@ $@-t
 	$(AM_V_GEN)$(do_subst) "$(srcdir)/$@.in" > $@-t
 	$(AM_V_at)mv $@-t $@
@@ -81,3 +83,5 @@ $(CONF_FILE) $(SYSTEMD_SERVICE_FILE): Makefile
 $(CONF_FILE): $(srcdir)/$(CONF_FILE).in
 
 $(SYSTEMD_SERVICE_FILE): $(srcdir)/$(SYSTEMD_SERVICE_FILE).in
+
+$(SYSTEMD_TSERVICE_FILE): $(srcdir)/$(SYSTEMD_TSERVICE_FILE).in

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ please see the [INSTALL.md](INSTALL.md) file.
 - [Spotify](#spotify)
 - [LastFM](#lastfm)
 - [MPD clients](#mpd-clients)
+- [Running Multiple Instances](#running-multiple-instances)
 - [References](#references)
 
 
@@ -569,6 +570,21 @@ The following table shows what is working for a selection of MPD clients:
 | [mpc](http://www.musicpd.org/clients/mpc/)    | CLI    | Working commands: mpc, add, crop, current, del (ranges are not yet supported), play, next, prev (behaves like cdprev), pause, toggle, cdprev, seek, clear, outputs, enable, disable, playlist, ls, load, volume, repeat, random, single, search, find, list, update (initiates an init-rescan, the path argument is not supported)   |
 | [ympd](http://www.ympd.org/)                  | Web    | Everything except "add stream" should work |
 
+## Running Multiple Instances
+
+To run multiple instances of owntone on a server, you should copy
+`/etc/owntone.conf` to `/etc/owntone-zone.conf`, modify the three port
+settings to be unique (`general` -> `websocket_port`, `library` ->
+`port`, and `mpd` -> `port`), modify the database paths to be unique
+(`general` -> `db_path`, `db_backup_path`, and `db_cache_path`), and
+change the service name to be unique (`library` -> `name`).  You
+probably also want to disable local output (set `audio` -> `type =
+"disabled"`).
+
+Then run `owntone -c /etc/owntone-zone.conf` to run owntone with the new
+zone configuration.  Owntone has a `systemd` template which lets you
+run this automatically on systems that use systemd, where you can
+run `systemctl enable owntone@zone` to enable the `zone` template.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -573,18 +573,27 @@ The following table shows what is working for a selection of MPD clients:
 ## Running Multiple Instances
 
 To run multiple instances of owntone on a server, you should copy
-`/etc/owntone.conf` to `/etc/owntone-zone.conf`, modify the three port
-settings to be unique (`general` -> `websocket_port`, `library` ->
-`port`, and `mpd` -> `port`), modify the database paths to be unique
-(`general` -> `db_path`, `db_backup_path`, and `db_cache_path`), and
-change the service name to be unique (`library` -> `name`).  You
-probably also want to disable local output (set `audio` -> `type =
-"disabled"`).
+`/etc/owntone.conf` to `/etc/owntone-zone.conf` and modify the
+following to be unique across all instances:
+
+* the three port settings (`general` -> `websocket_port`,
+  `library` -> `port`, and `mpd` -> `port`)
+
+* the database paths (`general` -> `db_path`, `db_backup_path`, and `db_cache_path`)
+
+* the service name (`library` -> `name`).
+
+* you probably also want to disable local output (set `audio` -> `type =
+  "disabled"`).
 
 Then run `owntone -c /etc/owntone-zone.conf` to run owntone with the new
-zone configuration.  Owntone has a `systemd` template which lets you
-run this automatically on systems that use systemd, where you can
-run `systemctl enable owntone@zone` to enable the `zone` template.
+zone configuration.
+
+Owntone has a `systemd` template which lets you run this automatically
+on systems that use systemd.  You can start or enable the service for
+a `zone` by `sudo systemctl start owntone@zone` and check that it is
+running with `sudo systemctl status owntone@zone`.  Use `sudo
+systemctl enable ownton@zone` to get the service to start on reboot.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -573,8 +573,8 @@ The following table shows what is working for a selection of MPD clients:
 ## Running Multiple Instances
 
 To run multiple instances of owntone on a server, you should copy
-`/etc/owntone.conf` to `/etc/owntone-zone.conf` and modify the
-following to be unique across all instances:
+`/etc/owntone.conf` to `/etc/owntone-zone.conf` (for each `zone`) and
+modify the following to be unique across all instances:
 
 * the three port settings (`general` -> `websocket_port`,
   `library` -> `port`, and `mpd` -> `port`)

--- a/owntone.spec.in
+++ b/owntone.spec.in
@@ -102,6 +102,7 @@ exit 0
 %{_libdir}/%{name}/
 %{_datarootdir}/%{name}/
 %{_unitdir}/%{name}.service
+%{_unitdir}/%{name}@.service
 %attr(0750,%{username},%{groupname}) %{_localstatedir}/cache/%{name}
 %attr(0750,%{username},%{groupname}) %{homedir}
 %ghost %{_localstatedir}/log/%{name}.log

--- a/owntone@.service.in
+++ b/owntone@.service.in
@@ -1,25 +1,26 @@
-# Note: Please keep this file in sync with owntone@.service.in
+# Note: Please keep this file in sync with owntone.service.in
 
 [Unit]
-Description=DAAP/DACP (iTunes), RSP and MPD server, supports AirPlay and Remote
+Description=DAAP/DACP (iTunes), RSP, MPD server, with AirPlay and Remote - %I
 Documentation=man:owntone(8)
 Requires=network.target local-fs.target avahi-daemon.socket
 After=network.target sound.target remote-fs.target pulseaudio.service
 
 [Service]
-ExecStart=@sbindir@/owntone -f
+ExecStart=@sbindir@/owntone -f -c /etc/owntone-%I.conf
+SyslogIdentifier=owntone-%I
 
-# Constrain the upper limit of memory/swap that can be used; this prevents 
+# Constrain the upper limit of memory/swap that can be used; this prevents
 # the server from consuming all system memory (in event of bug/malformed user
-# curl/SMARTPL query etc) that would hang/freeze low resource and headless (ie 
+# curl/SMARTPL query etc) that would hang/freeze low resource and headless (ie
 # RPi) machines
 #
 # systemd will kill the process in such an event but would be auto-restarted as
 # per 'Restart' directive below
 #
 # Values derived from obersvations on rpi3 under load - limits are >50% above
-# seen high watermarks 
-# 
+# seen high watermarks
+#
 # https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
 MemoryMax=256M
 MemorySwapMax=32M
@@ -34,4 +35,3 @@ StartLimitInterval=600
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
This PR adds a systemd template service that gets installed along with the standard service unit.  It includes that template service in the RPM file, and updates the documentation (INSTALL.md) to describe, minimally, how to use it.

This is a primary approach to handle Issue #1189, although it would be best to be able to do it all from a single instance so you wouldn't have the potential to try to send two audio streams to one output (which doesn't work for obvious reasons).  