### PR TITLE
[http,conf] allow user to request no ssl peer verification

### DIFF
--- a/src/conffile.c
+++ b/src/conffile.c
@@ -69,6 +69,7 @@ static cfg_opt_t sec_general[] =
     CFG_INT("db_pragma_synchronous", -1, CFGF_NONE),
     CFG_STR("allow_origin", "*", CFGF_NONE),
     CFG_STR("user_agent", PACKAGE_NAME "/" PACKAGE_VERSION, CFGF_NONE),
+    CFG_BOOL("ssl_verifypeer", cfg_true, CFGF_NONE),
     CFG_BOOL("timer_test", cfg_false, CFGF_NONE),
     CFG_END()
   };

--- a/src/http.c
+++ b/src/http.c
@@ -102,6 +102,7 @@ http_client_request(struct http_client_ctx *ctx)
   struct curl_slist *headers;
   struct onekeyval *okv;
   const char *user_agent;
+  long verifypeer;
   char header[1024];
   long response_code;
 
@@ -115,6 +116,9 @@ http_client_request(struct http_client_ctx *ctx)
   user_agent = cfg_getstr(cfg_getsec(cfg, "general"), "user_agent");
   curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent);
   curl_easy_setopt(curl, CURLOPT_URL, ctx->url);
+
+  verifypeer = cfg_getbool(cfg_getsec(cfg, "general"), "ssl_verifypeer");
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, verifypeer);
 
   headers = NULL;
   if (ctx->output_headers)


### PR DESCRIPTION
This solves for the case where hosted RSS podcasts have self signed or expired certs:  using default (verify peer) in these instances results in a `libcurl` error: `SSL peer certificate or SSH remote key was not OK`.

This also appears to be a libcurl version issue - running on this on Fedora 35 I don't get this problem with the master branch, running against libcurl 7.79.1 but this problem does appears on my RPi1 running `buster` with libcurl 7.64
```
$ ldd /usr/sbin/owntone | grep curl
	libcurl-gnutls.so.4 => /usr/lib/arm-linux-gnueabihf/libcurl-gnutls.so.4 (0xb5496000)
$ dpkg -S /usr/lib/arm-linux-gnueabihf/libcurl-gnutls.so.4
libcurl3-gnutls:armhf: /usr/lib/arm-linux-gnueabihf/libcurl-gnutls.so.4
$ $ apt show libcurl3-gnutls:armhf
Package: libcurl3-gnutls
Version: 7.64.0-4
```
By default we enforce peer verification as is default behaviour with libcurl api.