### PR TITLE
Fetch additional meta data in "browse" queries

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -1677,7 +1677,7 @@ GET /api/library/genres
 
 | Key             | Type     | Value                                     |
 | --------------- | -------- | ----------------------------------------- |
-| items           | array    | Array of [`genre`](#genre-object) objects |
+| items           | array    | Array of [`browse-info`](#browse-info-object) objects |
 | total           | integer  | Total number of genres in the library     |
 | offset          | integer  | Requested offset of the first genre       |
 | limit           | integer  | Requested maximum number of genres        |
@@ -2604,11 +2604,17 @@ curl --include \
 | limit           | integer  | Requested maximum number of items         |
 
 
-### `genre` object
+### `browse-info` object
 
 | Key             | Type     | Value                                     |
 | --------------- | -------- | ----------------------------------------- |
-| name            | string   | Name of genre                             |
+| name            | string   | Name (depends on the type of the query)   |
+| name_sort       | string   | Sort name                                 |
+| artist_count    | integer  | Number of artists                         |
+| album_count     | integer  | Number of albums                          |
+| track_count     | integer  | Number of tracks                          |
+| time_played     | string   | Timestamp in `ISO 8601` format           |
+| time_added      | string   | Timestamp in `ISO 8601` format           |
 
 
 ### `directory` object

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -1377,7 +1377,7 @@ source_group_dir_get(struct artwork_ctx *ctx)
       return ART_E_ERROR;
     }
 
-  while (((ret = db_query_fetch_string(&qp, &dir)) == 0) && (dir))
+  while (((ret = db_query_fetch_string(&dir, &qp)) == 0) && (dir))
     {
       /* The db query may return non-directories (eg if item is an internet stream or Spotify) */
       if (access(dir, F_OK) < 0)
@@ -1718,7 +1718,7 @@ source_item_ownpl_get(struct artwork_ctx *ctx)
   mfi_path = ctx->dbmfi->path;
 
   format = ART_E_NONE;
-  while (((ret = db_query_fetch_pl(&qp, &dbpli)) == 0) && (dbpli.id) && (format == ART_E_NONE))
+  while (((ret = db_query_fetch_pl(&dbpli, &qp)) == 0) && (dbpli.id) && (format == ART_E_NONE))
     {
       if (!dbpli.path)
 	continue;
@@ -1766,7 +1766,7 @@ process_items(struct artwork_ctx *ctx, int item_mode)
       return -1;
     }
 
-  while ((ret = db_query_fetch_file(&ctx->qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, &ctx->qp)) == 0)
     {
       // Save the first songalbumid, might need it for process_group() if this search doesn't give anything
       if (!ctx->persistentid)
@@ -1859,7 +1859,7 @@ process_group(struct artwork_ctx *ctx)
       goto invalid_group;
     }
 
-  is_valid = (db_query_fetch_file(&ctx->qp, &dbmfi) == 0 && strcmp(dbmfi.album, CFG_NAME_UNKNOWN_ALBUM) != 0 && strcmp(dbmfi.album_artist, CFG_NAME_UNKNOWN_ARTIST) != 0);
+  is_valid = (db_query_fetch_file(&dbmfi, &ctx->qp) == 0 && strcmp(dbmfi.album, CFG_NAME_UNKNOWN_ALBUM) != 0 && strcmp(dbmfi.album_artist, CFG_NAME_UNKNOWN_ARTIST) != 0);
   db_query_end(&ctx->qp);
   if (!is_valid)
     {

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -1766,7 +1766,7 @@ process_items(struct artwork_ctx *ctx, int item_mode)
       return -1;
     }
 
-  while (((ret = db_query_fetch_file(&ctx->qp, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(&ctx->qp, &dbmfi)) == 0)
     {
       // Save the first songalbumid, might need it for process_group() if this search doesn't give anything
       if (!ctx->persistentid)
@@ -1859,7 +1859,7 @@ process_group(struct artwork_ctx *ctx)
       goto invalid_group;
     }
 
-  is_valid = (db_query_fetch_file(&ctx->qp, &dbmfi) == 0 && dbmfi.id && strcmp(dbmfi.album, CFG_NAME_UNKNOWN_ALBUM) != 0 && strcmp(dbmfi.album_artist, CFG_NAME_UNKNOWN_ARTIST) != 0);
+  is_valid = (db_query_fetch_file(&ctx->qp, &dbmfi) == 0 && strcmp(dbmfi.album, CFG_NAME_UNKNOWN_ALBUM) != 0 && strcmp(dbmfi.album_artist, CFG_NAME_UNKNOWN_ARTIST) != 0);
   db_query_end(&ctx->qp);
   if (!is_valid)
     {

--- a/src/db.c
+++ b/src/db.c
@@ -2418,7 +2418,7 @@ db_query_fetch(void *item, struct query_params *qp, const ssize_t cols_map[], in
 }
 
 int
-db_query_fetch_file(struct query_params *qp, struct db_media_file_info *dbmfi)
+db_query_fetch_file(struct db_media_file_info *dbmfi, struct query_params *qp)
 {
   int ret;
 
@@ -2438,7 +2438,7 @@ db_query_fetch_file(struct query_params *qp, struct db_media_file_info *dbmfi)
 }
 
 int
-db_query_fetch_pl(struct query_params *qp, struct db_playlist_info *dbpli)
+db_query_fetch_pl(struct db_playlist_info *dbpli, struct query_params *qp)
 {
   int ncols;
   char **strcol;
@@ -2505,7 +2505,7 @@ db_query_fetch_pl(struct query_params *qp, struct db_playlist_info *dbpli)
 }
 
 int
-db_query_fetch_group(struct query_params *qp, struct db_group_info *dbgri)
+db_query_fetch_group(struct db_group_info *dbgri, struct query_params *qp)
 {
   int ret;
 
@@ -2525,7 +2525,7 @@ db_query_fetch_group(struct query_params *qp, struct db_group_info *dbgri)
 }
 
 int
-db_query_fetch_browse(struct query_params *qp, struct db_browse_info *dbbi)
+db_query_fetch_browse(struct db_browse_info *dbbi, struct query_params *qp)
 {
   int ret;
 
@@ -2545,7 +2545,7 @@ db_query_fetch_browse(struct query_params *qp, struct db_browse_info *dbbi)
 }
 
 int
-db_query_fetch_count(struct query_params *qp, struct filecount_info *fci)
+db_query_fetch_count(struct filecount_info *fci, struct query_params *qp)
 {
   int ret;
 
@@ -2596,7 +2596,7 @@ db_filecount_get(struct filecount_info *fci, struct query_params *qp)
       return -1;
     }
 
-  ret = db_query_fetch_count(qp, fci);
+  ret = db_query_fetch_count(fci, qp);
   if (ret < 0)
     {
       db_query_end(qp);
@@ -2609,7 +2609,7 @@ db_filecount_get(struct filecount_info *fci, struct query_params *qp)
 }
 
 int
-db_query_fetch_string(struct query_params *qp, char **string)
+db_query_fetch_string(char **string, struct query_params *qp)
 {
   int ret;
 
@@ -2640,7 +2640,7 @@ db_query_fetch_string(struct query_params *qp, char **string)
 }
 
 int
-db_query_fetch_string_sort(struct query_params *qp, char **string, char **sortstring)
+db_query_fetch_string_sort(char **string, char **sortstring, struct query_params *qp)
 {
   int ret;
 
@@ -3863,7 +3863,7 @@ db_pl_delete_bypath(const char *path)
       return;
     }
 
-  while (((ret = db_query_fetch_pl(&qp, &dbpli)) == 0) && (dbpli.id))
+  while (((ret = db_query_fetch_pl(&dbpli, &qp)) == 0) && (dbpli.id))
     {
       if (safe_atoi32(dbpli.id, &id) != 0)
 	continue;
@@ -5119,7 +5119,7 @@ db_queue_add_by_query(struct query_params *qp, char reshuffle, uint32_t item_id,
 	goto end_transaction;
     }
 
-  while ((ret = db_query_fetch_file(qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, qp)) == 0)
     {
       ret = queue_item_add_from_file(&dbmfi, pos, queue_count, queue_version);
 

--- a/src/db.h
+++ b/src/db.h
@@ -603,25 +603,25 @@ void
 db_query_end(struct query_params *qp);
 
 int
-db_query_fetch_file(struct query_params *qp, struct db_media_file_info *dbmfi);
+db_query_fetch_file(struct db_media_file_info *dbmfi, struct query_params *qp);
 
 int
-db_query_fetch_pl(struct query_params *qp, struct db_playlist_info *dbpli);
+db_query_fetch_pl(struct db_playlist_info *dbpli, struct query_params *qp);
 
 int
-db_query_fetch_group(struct query_params *qp, struct db_group_info *dbgri);
+db_query_fetch_group(struct db_group_info *dbgri, struct query_params *qp);
 
 int
-db_query_fetch_browse(struct query_params *qp, struct db_browse_info *dbbi);
+db_query_fetch_browse(struct db_browse_info *dbbi, struct query_params *qp);
 
 int
-db_query_fetch_count(struct query_params *qp, struct filecount_info *fci);
+db_query_fetch_count(struct filecount_info *fci, struct query_params *qp);
 
 int
-db_query_fetch_string(struct query_params *qp, char **string);
+db_query_fetch_string(char **string, struct query_params *qp);
 
 int
-db_query_fetch_string_sort(struct query_params *qp, char **string, char **sortstring);
+db_query_fetch_string_sort(char **string, char **sortstring, struct query_params *qp);
 
 /* Files */
 int

--- a/src/db.h
+++ b/src/db.h
@@ -409,6 +409,10 @@ struct db_media_file_info {
 
 #define dbmfi_offsetof(field) offsetof(struct db_media_file_info, field)
 
+/* Info object for generic browse queries that want more info than just
+ * the item string and sort string (e. g. for genre or compose queries
+ * that want to display the total track / album count).
+ */
 struct db_browse_info {
   char *itemname;
   char *itemname_sort;

--- a/src/db.h
+++ b/src/db.h
@@ -409,6 +409,24 @@ struct db_media_file_info {
 
 #define dbmfi_offsetof(field) offsetof(struct db_media_file_info, field)
 
+struct db_browse_info {
+  char *itemname;
+  char *itemname_sort;
+  char *track_count;
+  char *album_count;
+  char *artist_count;
+  char *song_length;
+  char *data_kind;
+  char *media_kind;
+  char *year;
+  char *date_released;
+  char *time_added;
+  char *time_played;
+  char *seek;
+};
+
+#define dbbi_offsetof(field) offsetof(struct db_browse_info, field)
+
 enum strip_type {
   STRIP_NONE,
   STRIP_PATH,
@@ -592,6 +610,9 @@ db_query_fetch_pl(struct query_params *qp, struct db_playlist_info *dbpli);
 
 int
 db_query_fetch_group(struct query_params *qp, struct db_group_info *dbgri);
+
+int
+db_query_fetch_browse(struct query_params *qp, struct db_browse_info *dbbi);
 
 int
 db_query_fetch_count(struct query_params *qp, struct filecount_info *fci);

--- a/src/httpd_daap.c
+++ b/src/httpd_daap.c
@@ -1271,7 +1271,7 @@ daap_reply_songlist_generic(struct httpd_request *hreq, int playlist)
 
   nsongs = 0;
   last_codectype = NULL;
-  while (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
     {
       nsongs++;
 

--- a/src/httpd_daap.c
+++ b/src/httpd_daap.c
@@ -1271,7 +1271,7 @@ daap_reply_songlist_generic(struct httpd_request *hreq, int playlist)
 
   nsongs = 0;
   last_codectype = NULL;
-  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
     {
       nsongs++;
 
@@ -1479,7 +1479,7 @@ daap_reply_playlists(struct httpd_request *hreq)
     }
 
   npls = 0;
-  while (((ret = db_query_fetch_pl(&qp, &dbpli)) == 0) && (dbpli.id))
+  while (((ret = db_query_fetch_pl(&dbpli, &qp)) == 0) && (dbpli.id))
     {
       plid = 1;
       if (safe_atoi32(dbpli.id, &plid) != 0)
@@ -1705,7 +1705,7 @@ daap_reply_groups(struct httpd_request *hreq)
     }
 
   ngrp = 0;
-  while ((ret = db_query_fetch_group(&qp, &dbgri)) == 0)
+  while ((ret = db_query_fetch_group(&dbgri, &qp)) == 0)
     {
       /* Don't add item if no name (eg blank album name) */
       if (strlen(dbgri.itemname) == 0)
@@ -1901,7 +1901,7 @@ daap_reply_browse(struct httpd_request *hreq)
     }
 
   nitems = 0;
-  while (((ret = db_query_fetch_string_sort(&qp, &browse_item, &sort_item)) == 0) && (browse_item))
+  while (((ret = db_query_fetch_string_sort(&browse_item, &sort_item, &qp)) == 0) && (browse_item))
     {
       nitems++;
 

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -253,7 +253,7 @@ find_first_song_id(const char *query)
       goto no_query_start;
     }
 
-  if (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+  if ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
     {
       ret = safe_atoi32(dbmfi.id, &id);
       if (ret < 0)
@@ -264,7 +264,6 @@ find_first_song_id(const char *query)
 	}
 
       DPRINTF(E_DBG, L_DACP, "Found index song (id %d)\n", id);
-      ret = 1;
     }
   else
     {
@@ -280,7 +279,7 @@ find_first_song_id(const char *query)
   if (qp.filter)
     free(qp.filter);
 
-  if (ret == 1)
+  if (id > 0)
     return id;
   else
     return -1;

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -253,7 +253,7 @@ find_first_song_id(const char *query)
       goto no_query_start;
     }
 
-  if ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+  if ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
     {
       ret = safe_atoi32(dbmfi.id, &id);
       if (ret < 0)

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -458,7 +458,7 @@ fetch_tracks(struct query_params *query_params, json_object *items, int *total)
   if (ret < 0)
     goto error;
 
-  while ((ret = db_query_fetch_file(query_params, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, query_params)) == 0)
     {
       item = track_to_json(&dbmfi);
       if (!item)
@@ -490,7 +490,7 @@ fetch_artists(struct query_params *query_params, json_object *items, int *total)
   if (ret < 0)
     goto error;
 
-  while ((ret = db_query_fetch_group(query_params, &dbgri)) == 0)
+  while ((ret = db_query_fetch_group(&dbgri, query_params)) == 0)
     {
       /* Don't add item if no name (eg blank album name) */
       if (strlen(dbgri.itemname) == 0)
@@ -535,7 +535,7 @@ fetch_artist(bool *notfound, const char *artist_id)
   if (ret < 0)
     goto error;
 
-  if ((ret = db_query_fetch_group(&query_params, &dbgri)) == 0)
+  if ((ret = db_query_fetch_group(&dbgri, &query_params)) == 0)
     {
       artist = artist_to_json(&dbgri);
       notfound = false;
@@ -559,7 +559,7 @@ fetch_albums(struct query_params *query_params, json_object *items, int *total)
   if (ret < 0)
     goto error;
 
-  while ((ret = db_query_fetch_group(query_params, &dbgri)) == 0)
+  while ((ret = db_query_fetch_group(&dbgri, query_params)) == 0)
     {
       /* Don't add item if no name (eg blank album name) */
       if (strlen(dbgri.itemname) == 0)
@@ -605,7 +605,7 @@ fetch_album(bool *notfound, const char *album_id)
   if (ret < 0)
     goto error;
 
-  if ((ret = db_query_fetch_group(&query_params, &dbgri)) == 0)
+  if ((ret = db_query_fetch_group(&dbgri, &query_params)) == 0)
     {
       album = album_to_json(&dbgri);
       *notfound = false;
@@ -629,7 +629,7 @@ fetch_playlists(struct query_params *query_params, json_object *items, int *tota
   if (ret < 0)
     goto error;
 
-  while (((ret = db_query_fetch_pl(query_params, &dbpli)) == 0) && (dbpli.id))
+  while (((ret = db_query_fetch_pl(&dbpli, query_params)) == 0) && (dbpli.id))
     {
       item = playlist_to_json(&dbpli);
       if (!item)
@@ -671,7 +671,7 @@ fetch_playlist(bool *notfound, uint32_t playlist_id)
   if (ret < 0)
     goto error;
 
-  if (((ret = db_query_fetch_pl(&query_params, &dbpli)) == 0) && (dbpli.id))
+  if (((ret = db_query_fetch_pl(&dbpli, &query_params)) == 0) && (dbpli.id))
     {
       playlist = playlist_to_json(&dbpli);
       *notfound = false;
@@ -695,7 +695,7 @@ fetch_genres(struct query_params *query_params, json_object *items, int *total)
   if (ret < 0)
     goto error;
 
-  while (((ret = db_query_fetch_browse(query_params, &dbbi)) == 0) && (dbbi.track_count))
+  while ((ret = db_query_fetch_browse(&dbbi, query_params)) == 0)
     {
       item = browse_info_to_json(&dbbi);
       if (!item)
@@ -3319,7 +3319,7 @@ jsonapi_reply_library_tracks_get_byid(struct httpd_request *hreq)
   if (ret < 0)
     goto error;
 
-  ret = db_query_fetch_file(&query_params, &dbmfi);
+  ret = db_query_fetch_file(&dbmfi, &query_params);
   if (ret < 0)
     goto error;
   else if (ret == 1)

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -458,7 +458,7 @@ fetch_tracks(struct query_params *query_params, json_object *items, int *total)
   if (ret < 0)
     goto error;
 
-  while (((ret = db_query_fetch_file(query_params, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(query_params, &dbmfi)) == 0)
     {
       item = track_to_json(&dbmfi);
       if (!item)
@@ -3322,8 +3322,7 @@ jsonapi_reply_library_tracks_get_byid(struct httpd_request *hreq)
   ret = db_query_fetch_file(&query_params, &dbmfi);
   if (ret < 0)
     goto error;
-
-  if (dbmfi.id == 0)
+  else if (ret == 1)
     {
       DPRINTF(E_LOG, L_WEB, "Track with id '%s' not found.\n", track_id);
       ret = -1;

--- a/src/httpd_rsp.c
+++ b/src/httpd_rsp.c
@@ -588,7 +588,7 @@ rsp_reply_playlist(struct httpd_request *hreq)
   mxmlNewTextf(node, 0, "%d", qp.results);
 
   /* Items block (all items) */
-  while (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
     {
       headers = evhttp_request_get_input_headers(hreq->req);
 

--- a/src/httpd_rsp.c
+++ b/src/httpd_rsp.c
@@ -441,7 +441,7 @@ rsp_reply_db(struct httpd_request *hreq)
   mxmlNewTextf(node, 0, "%d", qp.results);
 
   /* Playlists block (all playlists) */
-  while (((ret = db_query_fetch_pl(&qp, &dbpli)) == 0) && (dbpli.id))
+  while (((ret = db_query_fetch_pl(&dbpli, &qp)) == 0) && (dbpli.id))
     {
       // Skip non-local playlists, can't be streamed to the device
       if (!dbpli.path || dbpli.path[0] != '/')
@@ -588,7 +588,7 @@ rsp_reply_playlist(struct httpd_request *hreq)
   mxmlNewTextf(node, 0, "%d", qp.results);
 
   /* Items block (all items) */
-  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
     {
       headers = evhttp_request_get_input_headers(hreq->req);
 
@@ -772,7 +772,7 @@ rsp_reply_browse(struct httpd_request *hreq)
   mxmlNewTextf(node, 0, "%d", qp.results);
 
   /* Items block (all items) */
-  while (((ret = db_query_fetch_string(&qp, &browse_item)) == 0) && (browse_item))
+  while (((ret = db_query_fetch_string(&browse_item, &qp)) == 0) && (browse_item))
     {
       node = mxmlNewElement(items, "item");
       mxmlNewText(node, 0, browse_item);

--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -982,7 +982,7 @@ pipelist_create(void)
     return NULL;
 
   head = NULL;
-  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
     {
       ret = safe_atoi32(dbmfi.id, &id);
       if (ret < 0)

--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -982,7 +982,7 @@ pipelist_create(void)
     return NULL;
 
   head = NULL;
-  while (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
     {
       ret = safe_atoi32(dbmfi.id, &id);
       if (ret < 0)

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -1909,7 +1909,7 @@ playlist_add_files(FILE *fp, int pl_id, const char *virtual_path)
 
   if (qp.results > 0)
     {
-      while (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+      while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
         {
 	  if ((safe_atou32(dbmfi.data_kind, &data_kind) < 0)
 	      || (data_kind == DATA_KIND_PIPE))

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -1909,7 +1909,7 @@ playlist_add_files(FILE *fp, int pl_id, const char *virtual_path)
 
   if (qp.results > 0)
     {
-      while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+      while ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
         {
 	  if ((safe_atou32(dbmfi.data_kind, &data_kind) < 0)
 	      || (data_kind == DATA_KIND_PIPE))

--- a/src/library/filescanner_itunes.c
+++ b/src/library/filescanner_itunes.c
@@ -390,7 +390,7 @@ mfi_id_find(const char *path)
 
   winner = NULL;
   score = 0;
-  while ((db_query_fetch_string(&qp, &dbpath) == 0) && dbpath)
+  while ((db_query_fetch_string(&dbpath, &qp) == 0) && dbpath)
     {
       if (qp.results == 1)
 	{

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -317,7 +317,7 @@ process_regular_file(int pl_id, char *path)
 
   winner = NULL;
   score = 0;
-  while ((db_query_fetch_string(&qp, &dbpath) == 0) && dbpath)
+  while ((db_query_fetch_string(&dbpath, &qp) == 0) && dbpath)
     {
       if (qp.results == 1)
 	{

--- a/src/library/rssscanner.c
+++ b/src/library/rssscanner.c
@@ -568,7 +568,7 @@ rss_scan_all(enum rss_scan_type scan_type)
     }
 
   count = 0;
-  while (((ret = db_query_fetch_pl(&qp, &dbpli)) == 0) && (dbpli.path))
+  while (((ret = db_query_fetch_pl(&dbpli, &qp)) == 0) && (dbpli.path))
     {
       ret = rss_scan(dbpli.path, scan_type);
       if (ret == 0)

--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -1508,7 +1508,7 @@ cleanup_spotify_files(void)
       return -1;
     }
 
-  while (((ret = db_query_fetch_string(&qp, &path)) == 0) && (path))
+  while (((ret = db_query_fetch_string(&path, &qp)) == 0) && (path))
     {
       cache_artwork_delete_by_path(path);
     }

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2317,7 +2317,7 @@ mpd_command_listplaylist(struct evbuffer *evbuf, int argc, char **argv, char **e
       return ACK_ERROR_UNKNOWN;
     }
 
-  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
     {
       evbuffer_add_printf(evbuf,
 	  "file: %s\n",
@@ -2380,7 +2380,7 @@ mpd_command_listplaylistinfo(struct evbuffer *evbuf, int argc, char **argv, char
       return ACK_ERROR_UNKNOWN;
     }
 
-  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
     {
       ret = mpd_add_db_media_file_info(evbuf, &dbmfi);
       if (ret < 0)
@@ -2426,7 +2426,7 @@ mpd_command_listplaylists(struct evbuffer *evbuf, int argc, char **argv, char **
       return ACK_ERROR_UNKNOWN;
     }
 
-  while (((ret = db_query_fetch_pl(&qp, &dbpli)) == 0) && (dbpli.id))
+  while (((ret = db_query_fetch_pl(&dbpli, &qp)) == 0) && (dbpli.id))
     {
       if (safe_atou32(dbpli.db_timestamp, &time_modified) != 0)
 	{
@@ -2672,7 +2672,7 @@ mpd_command_find(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, s
       return ACK_ERROR_UNKNOWN;
     }
 
-  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
     {
       ret = mpd_add_db_media_file_info(evbuf, &dbmfi);
       if (ret < 0)
@@ -2777,7 +2777,7 @@ mpd_command_list(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, s
       return ACK_ERROR_UNKNOWN;
     }
 
-  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
     {
       strval = (char **) ((char *)&dbmfi + tagtype->mfi_offset);
 
@@ -2843,7 +2843,7 @@ mpd_add_directory(struct evbuffer *evbuf, int directory_id, int listall, int lis
       *errmsg = safe_asprintf("Could not start query");
       return ACK_ERROR_UNKNOWN;
     }
-  while (((ret = db_query_fetch_pl(&qp, &dbpli)) == 0) && (dbpli.id))
+  while (((ret = db_query_fetch_pl(&dbpli, &qp)) == 0) && (dbpli.id))
     {
       if (safe_atou32(dbpli.db_timestamp, &time_modified) != 0)
 	{
@@ -2917,7 +2917,7 @@ mpd_add_directory(struct evbuffer *evbuf, int directory_id, int listall, int lis
       *errmsg = safe_asprintf("Could not start query");
       return ACK_ERROR_UNKNOWN;
     }
-  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
     {
       if (listinfo)
 	{
@@ -3140,7 +3140,7 @@ mpd_command_search(struct evbuffer *evbuf, int argc, char **argv, char **errmsg,
       return ACK_ERROR_UNKNOWN;
     }
 
-  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
     {
       ret = mpd_add_db_media_file_info(evbuf, &dbmfi);
       if (ret < 0)
@@ -3392,7 +3392,7 @@ mpd_sticker_find(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, c
       return ret;
     }
 
-  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
+  while ((ret = db_query_fetch_file(&dbmfi, &qp)) == 0)
     {
       ret = safe_atou32(dbmfi.rating, &rating);
       if (ret < 0)

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2317,7 +2317,7 @@ mpd_command_listplaylist(struct evbuffer *evbuf, int argc, char **argv, char **e
       return ACK_ERROR_UNKNOWN;
     }
 
-  while (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
     {
       evbuffer_add_printf(evbuf,
 	  "file: %s\n",
@@ -2380,7 +2380,7 @@ mpd_command_listplaylistinfo(struct evbuffer *evbuf, int argc, char **argv, char
       return ACK_ERROR_UNKNOWN;
     }
 
-  while (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
     {
       ret = mpd_add_db_media_file_info(evbuf, &dbmfi);
       if (ret < 0)
@@ -2672,7 +2672,7 @@ mpd_command_find(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, s
       return ACK_ERROR_UNKNOWN;
     }
 
-  while (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
     {
       ret = mpd_add_db_media_file_info(evbuf, &dbmfi);
       if (ret < 0)
@@ -2777,7 +2777,7 @@ mpd_command_list(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, s
       return ACK_ERROR_UNKNOWN;
     }
 
-  while (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
     {
       strval = (char **) ((char *)&dbmfi + tagtype->mfi_offset);
 
@@ -2917,7 +2917,7 @@ mpd_add_directory(struct evbuffer *evbuf, int directory_id, int listall, int lis
       *errmsg = safe_asprintf("Could not start query");
       return ACK_ERROR_UNKNOWN;
     }
-  while (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
     {
       if (listinfo)
 	{
@@ -3140,7 +3140,7 @@ mpd_command_search(struct evbuffer *evbuf, int argc, char **argv, char **errmsg,
       return ACK_ERROR_UNKNOWN;
     }
 
-  while (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
     {
       ret = mpd_add_db_media_file_info(evbuf, &dbmfi);
       if (ret < 0)
@@ -3392,7 +3392,7 @@ mpd_sticker_find(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, c
       return ret;
     }
 
-  while (((ret = db_query_fetch_file(&qp, &dbmfi)) == 0) && (dbmfi.id))
+  while ((ret = db_query_fetch_file(&qp, &dbmfi)) == 0)
     {
       ret = safe_atou32(dbmfi.rating, &rating);
       if (ret < 0)


### PR DESCRIPTION
@ejurgensen I had a look at #1335 and I don't think adding additional methods to fetch the composer is a good idea. An alternative solution could be to extend the existing browse queries to include the additional meta data. This has the benefit, that the genre queries now also are able to fetch track count, artist count, etc.

This PR adds a "db_browse_info" struct and maps the now available meta data for genres in the JSON API.

While copy & pasting the code from the existing fetch-query-functions, I thought it would be good to refactor the logic into a generic function. The last commit in this PR does this refactoring. The refactoring is not done yet, especially changing the return value requires additional changes. This is why this PR is a draft. 

What do you think, is the refactoring worth the effort/risk? Or should I drop it.