### PR TITLE
Add "source" field to db and add support to update a single library source

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -141,6 +141,18 @@ enum data_kind {
 const char *
 db_data_kind_label(enum data_kind data_kind);
 
+enum scan_kind {
+  SCAN_KIND_UNKNOWN = 0,
+  SCAN_KIND_FILES = 1,
+  SCAN_KIND_SPOTIFY = 2,
+  SCAN_KIND_RSS = 3,
+};
+
+const char *
+db_scan_kind_label(enum scan_kind scan_kind);
+
+enum scan_kind
+db_scan_kind_enum(const char *label);
 
 /* Indicates user marked status on a track  - values can be bitwise enumerated */
 enum usermark {
@@ -234,6 +246,8 @@ struct media_file_info {
   char *album_sort;
   char *album_artist_sort;
   char *composer_sort;
+
+  uint32_t scan_kind; /* Identifies the library_source that created/updates this item */
 };
 
 #define mfi_offsetof(field) offsetof(struct media_file_info, field)
@@ -269,6 +283,7 @@ struct playlist_info {
   uint32_t query_limit;  /* limit, used by e.g. smart playlists */
   uint32_t media_kind;
   char *artwork_url;     /* optional artwork */
+  uint32_t scan_kind; /* Identifies the library_source that created/updates this item */
   uint32_t items;        /* number of items (mimc) */
   uint32_t streams;      /* number of internet streams */
 };
@@ -292,6 +307,7 @@ struct db_playlist_info {
   char *query_limit;
   char *media_kind;
   char *artwork_url;
+  char *scan_kind;
   char *items;
   char *streams;
 };
@@ -405,6 +421,7 @@ struct db_media_file_info {
   char *composer_sort;
   char *channels;
   char *usermark;
+  char *scan_kind;
 };
 
 #define dbmfi_offsetof(field) offsetof(struct db_media_file_info, field)
@@ -475,6 +492,7 @@ struct directory_info {
   uint32_t db_timestamp;
   int64_t disabled;
   uint32_t parent_id;
+  uint32_t scan_kind; /* Identifies the library_source that created/updates this item */
 };
 
 struct directory_enum {
@@ -588,6 +606,9 @@ db_hook_post_scan(void);
 
 void
 db_purge_cruft(time_t ref);
+
+void
+db_purge_cruft_bysource(time_t ref, enum scan_kind scan_kind);
 
 void
 db_purge_all(void);
@@ -798,16 +819,19 @@ void
 db_directory_enum_end(struct directory_enum *de);
 
 int
-db_directory_addorupdate(char *virtual_path, char *path, int disabled, int parent_id);
+db_directory_add(struct directory_info *di, int *id);
+
+int
+db_directory_update(struct directory_info *di);
 
 void
 db_directory_ping_bymatch(char *virtual_path);
 
 void
-db_directory_disable_bymatch(char *path, enum strip_type strip, uint32_t cookie);
+db_directory_disable_bymatch(const char *path, enum strip_type strip, uint32_t cookie);
 
 int
-db_directory_enable_bycookie(uint32_t cookie, char *path);
+db_directory_enable_bycookie(uint32_t cookie, const char *path);
 
 int
 db_directory_enable_bypath(char *path);

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -97,7 +97,8 @@
   "   album_artist_sort  VARCHAR(1024) DEFAULT NULL COLLATE DAAP,"	\
   "   composer_sort      VARCHAR(1024) DEFAULT NULL COLLATE DAAP,"	\
   "   channels           INTEGER DEFAULT 0,"		\
-  "   usermark           INTEGER DEFAULT 0"		\
+  "   usermark           INTEGER DEFAULT 0,"		\
+  "   scan_kind          INTEGER DEFAULT 0"		\
   ");"
 
 #define T_PL					\
@@ -117,7 +118,8 @@
   "   query_order    VARCHAR(1024),"			\
   "   query_limit    INTEGER DEFAULT 0,"		\
   "   media_kind     INTEGER DEFAULT 1,"		\
-  "   artwork_url    VARCHAR(4096) DEFAULT NULL"	\
+  "   artwork_url    VARCHAR(4096) DEFAULT NULL,"	\
+  "   scan_kind      INTEGER DEFAULT 0"			\
   ");"
 
 #define T_PLITEMS				\
@@ -166,7 +168,8 @@
   "   db_timestamp        INTEGER DEFAULT 0,"			\
   "   disabled            INTEGER DEFAULT 0,"			\
   "   parent_id           INTEGER DEFAULT 0,"			\
-  "   path                VARCHAR(4096) DEFAULT NULL"		\
+  "   path                VARCHAR(4096) DEFAULT NULL,"		\
+  "   scan_kind           INTEGER DEFAULT 0"			\
   ");"
 
 #define T_QUEUE								\

--- a/src/db_init.h
+++ b/src/db_init.h
@@ -25,8 +25,8 @@
  * version of the database? If yes, then it is a minor upgrade, if no, then it
  * is a major upgrade. In other words minor version upgrades permit downgrading
  * the server after the database was upgraded. */
-#define SCHEMA_VERSION_MAJOR 21
-#define SCHEMA_VERSION_MINOR 07
+#define SCHEMA_VERSION_MAJOR 22
+#define SCHEMA_VERSION_MINOR 0
 
 int
 db_init_indices(sqlite3 *hdl);

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1174,6 +1174,59 @@ static const struct db_upgrade_query db_upgrade_v2107_queries[] =
   };
 
 
+/* ---------------------------- 21.07 -> 22.00 ------------------------------ */
+
+#define U_v2200_ALTER_FILES_ADD_SCAN_KIND \
+  "ALTER TABLE files ADD COLUMN scan_kind INTEGER DEFAULT 0;"
+#define U_v2200_ALTER_PLAYLISTS_ADD_SCAN_KIND \
+  "ALTER TABLE playlists ADD COLUMN scan_kind INTEGER DEFAULT 0;"
+#define U_v2200_ALTER_DIR_ADD_SCAN_KIND \
+  "ALTER TABLE directories ADD COLUMN scan_kind INTEGER DEFAULT 0;"
+
+#define U_v2200_FILES_SET_SCAN_KIND_RSS \
+  "UPDATE files SET scan_kind = 3 WHERE path in ("      \
+  "  SELECT i.filepath from playlists p, playlistitems i WHERE p.id = i.playlistid AND p.type = 4);"
+#define U_v2200_FILES_SET_SCAN_KIND_SPOTIFY \
+  "UPDATE files SET scan_kind = 2 WHERE virtual_path like '/spotify:/%';"
+#define U_v2200_FILES_SET_SOURCE_FILE_SCANNER \
+  "UPDATE files SET scan_kind = 1 WHERE scan_kind = 0;"
+
+#define U_v2200_PL_SET_SCAN_KIND_RSS \
+  "UPDATE playlists SET scan_kind = 3 WHERE type = 4;" // PL_RSS  = 4
+#define U_v2200_PL_SET_SCAN_KIND_SPOTIFY \
+  "UPDATE playlists SET scan_kind = 2 WHERE virtual_path like '/spotify:/%';"
+#define U_v2200_PL_SET_SCAN_KIND_FILES \
+  "UPDATE playlists SET scan_kind = 1 WHERE scan_kind = 0;"
+
+// Note: RSS feed items do not have their own directory structure (they use "http:/")
+#define U_v2200_DIR_SET_SCAN_KIND_SPOTIFY \
+  "UPDATE directories SET scan_kind = 2 WHERE virtual_path like '/spotify:/%';"
+#define U_v2200_DIR_SET_SCAN_KIND_FILES \
+  "UPDATE directories SET scan_kind = 1 WHERE virtual_path like '/file:/%';"
+
+#define U_v2200_SCVER_MAJOR                    \
+  "UPDATE admin SET value = '22' WHERE key = 'schema_version_major';"
+#define U_v2200_SCVER_MINOR                    \
+  "UPDATE admin SET value = '00' WHERE key = 'schema_version_minor';"
+
+static const struct db_upgrade_query db_upgrade_v2200_queries[] =
+  {
+    { U_v2200_ALTER_FILES_ADD_SCAN_KIND, "alter table files add column scan_kind" },
+    { U_v2200_ALTER_PLAYLISTS_ADD_SCAN_KIND, "alter table playlists add column scan_kind" },
+    { U_v2200_ALTER_DIR_ADD_SCAN_KIND, "alter table directories add column scan_kind" },
+    { U_v2200_FILES_SET_SCAN_KIND_RSS, "update table files set scan_kind rss" },
+    { U_v2200_FILES_SET_SCAN_KIND_SPOTIFY, "update table files set scan_kind spotify" },
+    { U_v2200_FILES_SET_SOURCE_FILE_SCANNER, "update table files set scan_kind files" },
+    { U_v2200_PL_SET_SCAN_KIND_RSS, "update table playlists set scan_kind rss" },
+    { U_v2200_PL_SET_SCAN_KIND_SPOTIFY, "update table playlists set scan_kind spotify" },
+    { U_v2200_PL_SET_SCAN_KIND_FILES, "update table playlists set scan_kind files" },
+    { U_v2200_DIR_SET_SCAN_KIND_SPOTIFY, "update table directories set scan_kind spotify" },
+    { U_v2200_DIR_SET_SCAN_KIND_FILES , "update table directories set scan_kind files" },
+
+    { U_v2200_SCVER_MAJOR,    "set schema_version_major to 22" },
+    { U_v2200_SCVER_MINOR,    "set schema_version_minor to 00" },
+  };
+
 /* -------------------------- Main upgrade handler -------------------------- */
 
 int
@@ -1374,6 +1427,13 @@ db_upgrade(sqlite3 *hdl, int db_ver)
 
     case 2106:
       ret = db_generic_upgrade(hdl, db_upgrade_v2107_queries, ARRAY_SIZE(db_upgrade_v2107_queries));
+      if (ret < 0)
+	return -1;
+
+      /* FALLTHROUGH */
+
+    case 2107:
+      ret = db_generic_upgrade(hdl, db_upgrade_v2200_queries, ARRAY_SIZE(db_upgrade_v2200_queries));
       if (ret < 0)
 	return -1;
 

--- a/src/library.h
+++ b/src/library.h
@@ -54,7 +54,7 @@ enum library_cb_action
  */
 struct library_source
 {
-  char *name;
+  enum scan_kind scan_kind;
   int disabled;
 
   /*
@@ -134,6 +134,9 @@ library_media_save(struct media_file_info *mfi);
 int
 library_playlist_save(struct playlist_info *pli);
 
+int
+library_directory_save(char *virtual_path, char *path, int disabled, int parent_id, enum scan_kind library_source);
+
 /*
  * @param cb      Callback to call
  * @param arg     Argument to call back with
@@ -153,12 +156,27 @@ library_is_exiting();
 
 /* ------------------------ Library external interface --------------------- */
 
+/*
+ * Rescan library: find new, remove deleted and update modified tracks and playlists
+ * If a "source_name" is given, only tracks / playlists belonging to that source are
+ * updated.
+ *
+ * Update is done asynchronously in the library thread.
+ *
+ * @param library_source 0 to update everything, one of LIBRARY_SOURCE_xxx to only update specific source
+ */
 void
-library_rescan();
+library_rescan(enum scan_kind library_source);
 
+/*
+ * Same as library_rescan but also updates unmodified tracks and playlists
+ */
 void
-library_metarescan();
+library_metarescan(enum scan_kind library_source);
 
+/*
+ * Wipe library and do a full rescan of all library sources
+ */
 void
 library_fullrescan();
 
@@ -201,6 +219,8 @@ library_queue_item_add(const char *path, int position, char reshuffle, uint32_t 
 int
 library_item_add(const char *path);
 
+struct library_source **
+library_sources(void);
 
 /*
  * Execute the function 'func' with the given argument 'arg' in the library thread.

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -159,6 +159,7 @@ scan_metadata_stream(struct media_file_info *mfi, const char *path)
   mfi->data_kind = DATA_KIND_HTTP;
   mfi->time_modified = time(NULL);
   mfi->directory_id = DIR_HTTP;
+  mfi->scan_kind = SCAN_KIND_FILES;
 
   ret = scan_metadata_ffmpeg(mfi, path);
   if (ret < 0)
@@ -186,6 +187,7 @@ process_nested_playlist(int parent_id, const char *path)
     goto error;
 
   pli->type = PL_FOLDER;
+  pli->scan_kind = SCAN_KIND_FILES;
   ret = library_playlist_save(pli);
   if (ret < 0)
     goto error;

--- a/src/library/rssscanner.c
+++ b/src/library/rssscanner.c
@@ -217,6 +217,7 @@ playlist_fetch(bool *is_new, const char *path)
   pli->directory_id = DIR_HTTP;
   pli->type = PL_RSS;
   pli->query_limit = RSS_LIMIT_DEFAULT;
+  pli->scan_kind = SCAN_KIND_RSS;
 
   ret = library_playlist_save(pli);
   if (ret < 0)
@@ -487,6 +488,7 @@ rss_save(struct playlist_info *pli, int *count, enum rss_scan_type scan_type)
 	}
 
       scan_metadata_stream(&mfi, ri.url);
+      mfi.scan_kind = SCAN_KIND_RSS;
 
       mfi_metadata_fixup(&mfi, &ri, feed_title, feed_author, time_added);
 
@@ -641,7 +643,7 @@ rss_add(const char *path)
 
 struct library_source rssscanner =
 {
-  .name = "RSS feeds",
+  .scan_kind = SCAN_KIND_RSS,
   .disabled = 0,
   .initscan = rss_rescan,
   .rescan = rss_rescan,

--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -1465,7 +1465,7 @@ prepare_directories(const char *artist, const char *album)
       DPRINTF(E_LOG, L_SPOTIFY, "Virtual path exceeds PATH_MAX (/spotify:/%s)\n", artist);
       return -1;
     }
-  dir_id = db_directory_addorupdate(virtual_path, NULL, 0, DIR_SPOTIFY);
+  dir_id = library_directory_save(virtual_path, NULL, 0, DIR_SPOTIFY, SCAN_KIND_SPOTIFY);
   if (dir_id <= 0)
     {
       DPRINTF(E_LOG, L_SPOTIFY, "Could not add or update directory '%s'\n", virtual_path);
@@ -1477,7 +1477,7 @@ prepare_directories(const char *artist, const char *album)
       DPRINTF(E_LOG, L_SPOTIFY, "Virtual path exceeds PATH_MAX (/spotify:/%s/%s)\n", artist, album);
       return -1;
     }
-  dir_id = db_directory_addorupdate(virtual_path, NULL, 0, dir_id);
+  dir_id = library_directory_save(virtual_path, NULL, 0, dir_id, SCAN_KIND_SPOTIFY);
   if (dir_id <= 0)
     {
       DPRINTF(E_LOG, L_SPOTIFY, "Could not add or update directory '%s'\n", virtual_path);
@@ -1580,6 +1580,7 @@ map_track_to_mfi(struct media_file_info *mfi, const struct spotify_track *track,
     }
   snprintf(virtual_path, PATH_MAX, "/spotify:/%s/%s/%s", mfi->album_artist, mfi->album, mfi->title);
   mfi->virtual_path = strdup(virtual_path);
+  mfi->scan_kind = SCAN_KIND_SPOTIFY;
 }
 
 static int
@@ -1873,8 +1874,9 @@ map_playlist_to_pli(struct playlist_info *pli, struct spotify_playlist *playlist
   pli->path  = strdup(playlist->uri);
   pli->title = safe_strdup(playlist->name);
 
-  pli->parent_id    = spotify_base_plid;
-  pli->directory_id = DIR_SPOTIFY;
+  pli->parent_id      = spotify_base_plid;
+  pli->directory_id   = DIR_SPOTIFY;
+  pli->scan_kind = SCAN_KIND_SPOTIFY;
 
   if (playlist->owner)
     pli->virtual_path = safe_asprintf("/spotify:/%s (%s)", playlist->name, playlist->owner);
@@ -1945,6 +1947,7 @@ create_saved_tracks_playlist(void)
       .type = PL_PLAIN,
       .parent_id = spotify_base_plid,
       .directory_id = DIR_SPOTIFY,
+      .scan_kind = SCAN_KIND_SPOTIFY,
     };
 
   spotify_saved_plid = playlist_add_or_update(&pli);
@@ -1969,6 +1972,7 @@ create_base_playlist(void)
       .path = strdup("spotify:playlistfolder"),
       .title = strdup("Spotify"),
       .type = PL_FOLDER,
+      .scan_kind = SCAN_KIND_SPOTIFY,
     };
 
   spotify_base_plid = 0;
@@ -2330,7 +2334,7 @@ spotifywebapi_deinit()
 
 struct library_source spotifyscanner =
 {
-  .name = "spotifyscanner",
+  .scan_kind = SCAN_KIND_SPOTIFY,
   .disabled = 0,
   .init = spotifywebapi_init,
   .deinit = spotifywebapi_deinit,

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3203,7 +3203,7 @@ mpd_command_update(struct evbuffer *evbuf, int argc, char **argv, char **errmsg,
       return ACK_ERROR_ARG;
     }
 
-  library_rescan();
+  library_rescan(0);
 
   evbuffer_add(evbuf, "updating_db: 1\n", 15);
 


### PR DESCRIPTION
This PR implements a generic approach to trigger a library update for a single library source.
Usecases are updating only the Spotify library or updating the podcasts RSS feeds (alternative solution to #1323).

- The JSON API endpoints to trigger a library update now take an optional query parameter `source`) 
- The JSON API endpoint to fetch library information (`GET api/library`) now returns an additional attribute `sources` that list the available library sources
- Includes a DB update to DB version 21.08 (add new column `source` to files, playlists and directories table)
- Each library entry for files, playlists and directories now has a reference to the library source that created it / is responsible for it.

This PR does not include the web interface changes.

This PR requires more testing, but I want to hear your thoughts on this approach @ejurgensen 