### PR TITLE
[db] sqlext - handle diacritics in DAAP collation

### DIFF
--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -4290,9 +4290,9 @@ search_tracks(json_object *reply, struct httpd_request *hreq, const char *param_
   if (param_query)
     {
       if (media_kind)
-	query_params.filter = db_mprintf("(f.title LIKE '%%%q%%' AND f.media_kind = %d)", param_query, media_kind);
+	query_params.filter = db_mprintf("((f.title LIKE '%%%q%%' OR f.title = '%q') AND f.media_kind = %d)", param_query, param_query, media_kind);
       else
-	query_params.filter = db_mprintf("(f.title LIKE '%%%q%%')", param_query);
+	query_params.filter = db_mprintf("(f.title LIKE '%%%q%%' OR f.title = '%q')", param_query, param_query);
     }
   else
     {
@@ -4351,9 +4351,9 @@ search_artists(json_object *reply, struct httpd_request *hreq, const char *param
   if (param_query)
     {
       if (media_kind)
-	query_params.filter = db_mprintf("(f.album_artist LIKE '%%%q%%' AND f.media_kind = %d)", param_query, media_kind);
+	query_params.filter = db_mprintf("((f.album_artist LIKE '%%%q%%' OR f.album_artist = '%q') AND f.media_kind = %d)", param_query, param_query, media_kind);
       else
-	query_params.filter = db_mprintf("(f.album_artist LIKE '%%%q%%')", param_query);
+	query_params.filter = db_mprintf("(f.album_artist LIKE '%%%q%%' OR f.album_artist = '%q')", param_query, param_query);
     }
   else
     {
@@ -4413,9 +4413,9 @@ search_albums(json_object *reply, struct httpd_request *hreq, const char *param_
   if (param_query)
     {
       if (media_kind)
-	query_params.filter = db_mprintf("(f.album LIKE '%%%q%%' AND f.media_kind = %d)", param_query, media_kind);
+	query_params.filter = db_mprintf("((f.album LIKE '%%%q%%' OR f.album = '%q') AND f.media_kind = %d)", param_query, param_query, media_kind);
       else
-	query_params.filter = db_mprintf("(f.album LIKE '%%%q%%')", param_query);
+	query_params.filter = db_mprintf("(f.album LIKE '%%%q%%' OR f.album = '%q')", param_query, param_query);
     }
   else
     {
@@ -4475,9 +4475,9 @@ search_composers(json_object *reply, struct httpd_request *hreq, const char *par
   if (param_query)
     {
       if (media_kind)
-	query_params.filter = db_mprintf("(f.composer LIKE '%%%q%%' AND f.media_kind = %d)", param_query, media_kind);
+	query_params.filter = db_mprintf("((f.composer LIKE '%%%q%%' OR f.composer = '%q') AND f.media_kind = %d)", param_query, param_query, media_kind);
       else
-	query_params.filter = db_mprintf("(f.composer LIKE '%%%q%%')", param_query);
+	query_params.filter = db_mprintf("(f.composer LIKE '%%%q%%' OR f.composer = '%q')", param_query, param_query);
     }
   else
     {


### PR DESCRIPTION
Allows matched comparisons for strings like:
```
"foo"		"fóo"
"crème brûlée"	"creme brulee"
"smörgåsbord"	"smorgAsbord"
```

Notes  SQLite apparently ignores [collations](https://stackoverflow.com/questions/26871674/sqlite-custom-accent-collation-function-and-like-queries?rq=1) for [`LIKE`](https://docs.microsoft.com/en-us/dotnet/standard/data/sqlite/collation) which requires some additional work in the `httpd_jsonapi.c` and the `daap_parser.y`: going from `foo LIke "%xxx%"` to  adding `OR foo = "xxx" with the latter taking care of the diacritics