### PR TITLE
Fix for Spotify config option album_override has no effect

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1192,12 +1192,16 @@ fixup_defaults(char **tag, enum fixup_type fixup, struct fixup_ctx *ctx)
 	    *tag = strdup("");
 	  }
 
+	if (ctx->mfi && ctx->mfi->compilation && (ca = cfg_getstr(cfg_getsec(cfg, "library"), "compilation_artist")))
+	  {
+	    free(*tag);
+	    *tag = strdup(ca); // If ca is empty string then the artist will not be shown in artist view
+	  }
+
 	if (*tag)
 	  break;
 
-	if (ctx->mfi && ctx->mfi->compilation && (ca = cfg_getstr(cfg_getsec(cfg, "library"), "compilation_artist")))
-	  *tag = strdup(ca); // If ca is empty string then the artist will not be shown in artist view
-	else if (ctx->mfi && ctx->mfi->artist)
+	if (ctx->mfi && ctx->mfi->artist)
 	  *tag = strdup(ctx->mfi->artist);
 	else if (ctx->qi && ctx->qi->artist)
 	  *tag = strdup(ctx->qi->artist);


### PR DESCRIPTION
@ejurgensen @ben-willmore This PR should fix #1426 

I only did a short test ... would be great if you could test if it works for you.

@ejurgensen I noticed that the "artist_override" did still not work after the fix in `spotify_webapi.c`. The problem is, that the during the scan, the compilation flag did not result in setting the album artist to the configured compilation artist. This also effects local files stored in the compilation folder. My guess is, that the behavior broke with the change to prepared statements for track inserts. I fixed this with e5d3c148ea7f11b5c40ab555ef36b3ae552973a0 (in this PR). Please take a closer look at this commit.
