### PR TITLE
[web] slow 4.1.6 shutdown; request to cancel ws loop

### DIFF
--- a/src/websocket.c
+++ b/src/websocket.c
@@ -429,7 +429,6 @@ websocket(void *arg)
 #endif
   }
 
-  lws_context_destroy(context);
   pthread_exit(NULL);
 }
 
@@ -541,9 +540,11 @@ websocket_deinit(void)
     return;
 
   websocket_exit = true;
+  lws_cancel_service(context);
   ret = pthread_join(tid_websocket, NULL);
   if (ret < 0)
     DPRINTF(E_LOG, L_WEB, "Error joining websocket thread (%d): %s\n", ret, strerror(ret));
 
+  lws_context_destroy(context);
   pthread_mutex_destroy(&websocket_write_event_lock);
 }


### PR DESCRIPTION
Closes #1423

Cancels the websocket service in deinit for faster thread exit instead of waiting for weboskcet internal loop to timeout