### PR TITLE
Use newer reconnecting websocket and reconnect when page receives focus

### DIFF
--- a/web-src/package.json
+++ b/web-src/package.json
@@ -19,7 +19,7 @@
     "mdi": "^2.2.43",
     "moment": "^2.29.1",
     "moment-duration-format": "^2.3.2",
-    "reconnectingwebsocket": "^1.0.0",
+    "reconnecting-websocket": "^4.4.0",
     "spotify-web-api-js": "^1.5.2",
     "string-to-color": "^2.2.2",
     "vue": "^3.2.31",

--- a/web-src/src/App.vue
+++ b/web-src/src/App.vue
@@ -32,7 +32,7 @@ import ModalDialogRemotePairing from '@/components/ModalDialogRemotePairing.vue'
 import ModalDialogUpdate from '@/components/ModalDialogUpdate.vue'
 import webapi from '@/webapi'
 import * as types from '@/store/mutation_types'
-import ReconnectingWebSocket from 'reconnectingwebsocket'
+import ReconnectingWebSocket from 'reconnecting-websocket'
 import moment from 'moment'
 
 export default {
@@ -180,8 +180,8 @@ export default {
       }
 
       const socket = new ReconnectingWebSocket(wsUrl, 'notify', {
-        reconnectInterval: 1000,
-        maxReconnectInterval: 2000
+        minReconnectionDelay: 1000,
+        maxReconnectionDelay: 2000
       })
 
       socket.onopen = function () {
@@ -245,6 +245,8 @@ export default {
         if (update_throttled) {
           return
         }
+
+        socket.reconnect()
 
         vm.update_outputs()
         vm.update_player_status()


### PR DESCRIPTION
After quite a lot of testing of my previous fix (already merged by @chme), I found there is still a situation where the Now Playing (etc) information stops getting updated. It seems to depend on client platform -- on my laptop, I have to leave the OwnTone webpage in the background for a long time for it to occur, but on iPhone it happens within 15 seconds if I go to the Queue page, then switch to a different app on the phone, then switch back to the OwnTone tab.

The reconnecting websocket module is abandoned, and there is a newer version -- https://github.com/pladaria/reconnecting-websocket . Using this, and reconnecting the websocket when the web page receives focus, fixes the problem.