### PR TITLE
[http/spotify] Allow reuse of curl handle to improve Spotify scan performance

### DIFF
--- a/src/artwork.c
+++ b/src/artwork.c
@@ -439,7 +439,7 @@ artwork_read_byurl(struct evbuffer *evbuf, const char *url)
   client.input_headers = kv;
   client.input_body = evbuf;
 
-  ret = http_client_request(&client);
+  ret = http_client_request(&client, NULL);
   if (ret < 0)
     {
       DPRINTF(E_LOG, L_ART, "Request to '%s' failed with return value %d\n", url, ret);
@@ -1288,7 +1288,7 @@ online_source_search(struct online_source *src, struct artwork_ctx *ctx)
   client.url = url;
   client.output_headers = &output_headers;
 
-  ret = http_client_request(&client);
+  ret = http_client_request(&client, NULL);
   keyval_clear(&output_headers);
   if (ret < 0 || client.response_code != HTTP_OK)
     {

--- a/src/http.h
+++ b/src/http.h
@@ -4,9 +4,15 @@
 
 #include <event2/buffer.h>
 #include <event2/http.h>
+#include <curl/curl.h>
 #include "misc.h"
 
 #include <libavformat/avformat.h>
+
+struct http_client_session
+{
+  CURL *curl;
+};
 
 struct http_client_ctx
 {
@@ -54,6 +60,11 @@ struct http_icy_metadata
   uint32_t hash;
 };
 
+void
+http_client_session_init(struct http_client_session *session);
+
+void
+http_client_session_deinit(struct http_client_session *session);
 
 /* Make a http(s) request. We use libcurl to make https requests. We could use
  * libevent and avoid the dependency, but for SSL, libevent needs to be v2.1
@@ -63,7 +74,7 @@ struct http_icy_metadata
  * @return 0 if successful, -1 if an error occurred (e.g. no libcurl)
  */
 int
-http_client_request(struct http_client_ctx *ctx);
+http_client_request(struct http_client_ctx *ctx, struct http_client_session *session);
 
 
 /* Converts the keyval dictionary to a application/x-www-form-urlencoded string.

--- a/src/inputs/http.c
+++ b/src/inputs/http.c
@@ -194,7 +194,7 @@ streamurl_process(struct input_metadata *metadata, const char *url)
   client.input_headers = &kv;
   client.input_body = evbuf;
 
-  ret = http_client_request(&client);
+  ret = http_client_request(&client, NULL);
   if (ret < 0 || client.response_code != HTTP_OK)
     {
       DPRINTF(E_WARN, L_PLAYER, "Request for StreamUrl resource '%s' failed, response code %d\n", url, client.response_code);

--- a/src/inputs/spotify_librespotc.c
+++ b/src/inputs/spotify_librespotc.c
@@ -228,7 +228,7 @@ https_get_cb(char **out, const char *url)
   ctx.url = url;
   ctx.input_body = evbuffer_new();
 
-  ret = http_client_request(&ctx);
+  ret = http_client_request(&ctx, NULL);
   if (ret < 0 || ctx.response_code != HTTP_OK)
     {
       DPRINTF(E_LOG, L_SPOTIFY, "Failed to AP list from '%s' (return %d, error code %d)\n", ctx.url, ret, ctx.response_code);

--- a/src/lastfm.c
+++ b/src/lastfm.c
@@ -239,7 +239,7 @@ request_post(const char *url, struct keyval *kv, char **errmsg)
   ctx.url = url;
   ctx.input_body = evbuffer_new();
 
-  ret = http_client_request(&ctx);
+  ret = http_client_request(&ctx, NULL);
   if (ret < 0)
     goto out_free_ctx;
 

--- a/src/library/rssscanner.c
+++ b/src/library/rssscanner.c
@@ -144,7 +144,7 @@ apple_rss_feedurl_get(const char *rss_url)
   ctx.url = url;
   ctx.input_body = evbuf;
 
-  ret = http_client_request(&ctx);
+  ret = http_client_request(&ctx, NULL);
   if (ret < 0 || ctx.response_code != HTTP_OK)
     {
       evbuffer_free(evbuf);
@@ -256,7 +256,7 @@ rss_xml_get(const char *url)
   CHECK_NULL(L_LIB, ctx.input_body = evbuffer_new());
   ctx.url = feedurl;
 
-  ret = http_client_request(&ctx);
+  ret = http_client_request(&ctx, NULL);
   if (ret < 0 || ctx.response_code != HTTP_OK)
     {
       DPRINTF(E_LOG, L_LIB, "Failed to fetch RSS from '%s' (return %d, error code %d)\n", ctx.url, ret, ctx.response_code);


### PR DESCRIPTION
My Spotify library is getting larger and it takes now a significant amount of time to run the spotify library scan ...

One way I found to improve it is to reuse the curl handle. Reusing the handle - instead of creating a new one for each request - will keep the connections, session ID cache, DNS cache and cookies.

The implementation in this PR is a proof of concept.

Some "benchmarks" from my raspberry pi 3B:

Without reusing the curl handle (current master branch):

```
[2022-04-17 10:19:28] [  LOG]  spotify: Spotify scan completed in 313 sec
[2022-04-17 10:52:57] [  LOG]  spotify: Spotify scan completed in 212 sec
[2022-04-17 10:57:36] [  LOG]  spotify: Spotify scan completed in 248 sec
```

With reusing the curl handle (this PR branch):

```
[2022-04-17 11:10:09] [  LOG]  spotify: Spotify scan completed in 145 sec
[2022-04-17 11:13:45] [  LOG]  spotify: Spotify scan completed in 200 sec
[2022-04-17 11:17:12] [  LOG]  spotify: Spotify scan completed in 194 sec
```

(On my laptop the change has no measurable performance impact)

I am not sure how to best implement it. I was thinking instead of passing an optional curl handle to `http_client_request`, maybe it would be better to keep a curl handle per thread and make the use of it transparent to the caller of `http_client_request`. 

@ejurgensen I would appreciate your thoughts on this.
