### PR TITLE
[rcp] bug fix - speaker unselection upon restart / obey volume 

### DIFF
--- a/src/outputs/rcp.c
+++ b/src/outputs/rcp.c
@@ -1200,7 +1200,7 @@ rcp_device_stop(struct output_device *device, int callback_id)
    * these need use to select (and cause the device probe to start connection to
    * remote side
    */
-  device->prevent_playback = 1;
+  device->prevent_playback = 0;
 
   s->callback_id = callback_id;
   // tear this session down, incl free'ing it
@@ -1270,7 +1270,6 @@ static void
 rcp_mdns_device_cb(const char *name, const char *type, const char *domain, const char *hostname, int family, const char *address, int port, struct keyval *txt)
 {
   struct output_device *device;
-  struct player_speaker_info si;
   bool exclude;
   int ret;
 
@@ -1316,16 +1315,6 @@ rcp_mdns_device_cb(const char *name, const char *type, const char *domain, const
       DPRINTF(E_INFO, L_RCP, "Adding RCP output device '%s' at '%s'\n", name, address);
 
       ret = player_device_add(device);
-
-      if (ret == 0)
-	{
-	  ret = player_speaker_get_byid(&si, device->id);
-	  if (ret == 0 && si.selected)
-	    {
-	      // device previously selected, it's seen on network, force connection
-	      rcp_session_make(device, -1);
-	    }
-	}
     }
 
   if (ret < 0)

--- a/src/outputs/rcp.c
+++ b/src/outputs/rcp.c
@@ -809,8 +809,6 @@ rcp_session_shutdown(struct rcp_session* s, enum rcp_state state)
   event_del(s->ev);
   event_del(s->reply_timeout);
 
-  s->device->prevent_playback = 1;
-
   rcp_disconnect(s->sock);
   s->sock = -1;
 
@@ -951,7 +949,6 @@ rcp_listen_cb(int fd, short what, void *arg)
   // Downgrade state to make rcp_session_shutdown perform an exit which is
   // quick and won't require a reponse from remote
   s->state = RCP_STATE_FAILED;
-  s->device->prevent_playback = 1;
   rcp_session_shutdown(s, RCP_STATE_FAILED);
 }
 
@@ -966,7 +963,6 @@ rcp_reply_timeout_cb(int fd, short what, void *arg)
       DPRINTF(E_LOG, L_RCP, "Slow response from '%s' (state %d), shutting down\n", s->devname, s->state);
 
       s->state = RCP_STATE_FAILED;
-      s->device->prevent_playback = 1;
       rcp_session_shutdown(s, RCP_STATE_FAILED);
 
       event_del(s->reply_timeout);
@@ -1200,7 +1196,6 @@ rcp_device_stop(struct output_device *device, int callback_id)
    * these need use to select (and cause the device probe to start connection to
    * remote side
    */
-  device->prevent_playback = 0;
 
   s->callback_id = callback_id;
   // tear this session down, incl free'ing it
@@ -1215,7 +1210,6 @@ rcp_device_flush(struct output_device *device, int callback_id)
   struct rcp_session *s = device->session;
 
   s->callback_id = callback_id;
-  s->state = OUTPUT_STATE_STOPPED;
 
   rcp_status(s);
 


### PR DESCRIPTION
Two bugs:

- ensure device flag is `selected = 0` to reflect unconnected status (must initiate Soundbridge connection by design)
- sync volume of Soundbridge to last known volume as set by server
trying to fetch volume of soundbridge (which might have changed since last use by server) proving problematic and volume not reflecting correctly on web ui