### PR TITLE
[player] send volume event when a device fails

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -1506,7 +1506,7 @@ device_streaming_cb(struct output_device *device, enum output_device_state statu
   // We don't do this in the other cb's because they are triggered by a command
   // and thus the update should be done as part of the command completion (which
   // can better determine which type of listener event to use)
-  status_update(player_state, LISTENER_SPEAKER);
+  status_update(player_state, LISTENER_SPEAKER | LISTENER_VOLUME);
 }
 
 static void


### PR DESCRIPTION
Without this the web ui does not know that an output device failing, volume/selected status remains.

```
[2022-04-29 21:56:10] [ INFO]      rcp: Connection to 'RCP/SoundBridge Test Harness' established
[2022-04-29 21:56:11] [ INFO]      rcp: Ready 'RCP/SoundBridge Test Harness' volume at 23

*** kill the Roku

[2022-04-29 21:56:15] [  LOG]      rcp: Failed to read response from 'RCP/SoundBridge Test Harness' - Connection reset by peer
[2022-04-29 21:56:15] [  LOG]      rcp: Failed to recv/construct response from 'RCP/SoundBridge Test Harness'
[2022-04-29 21:56:15] [ INFO]      rcp: Disconnected 'RCP/SoundBridge Test Harness'
[2022-04-29 21:56:15] [ WARN]   player: The RCP/SoundBridge device 'RCP/SoundBridge Test Harness' failed
```
Without change, at the webui's speakers still show the Roku device with a volume and selected (ie not greyed out).