### PR TITLE
[streaming] refactor to use `outputs_quality_subscribe`

### DIFF
--- a/src/conffile.c
+++ b/src/conffile.c
@@ -256,7 +256,7 @@ static cfg_opt_t toplvl_cfg[] =
     CFG_SEC("spotify", sec_spotify, CFGF_NONE),
     CFG_SEC("sqlite", sec_sqlite, CFGF_NONE),
     CFG_SEC("mpd", sec_mpd, CFGF_NONE),
-    CFG_SEC("streaming", sec_streaming, CFGF_NONE),
+    CFG_SEC("streaming", sec_streaming, CFGF_MULTI | CFGF_TITLE),
     CFG_END()
   };
 


### PR DESCRIPTION
A rework of previous PR #982 

This refactors the `httpd_streaming` to:
* use `outputs_quality_subscribe()` to avoid transcoding within `httpd_streaming` module
* introduce `streaming_ctx` that represents specific streaming format (ie mp3, flac etc) to allow easier support of other formats / streaming endpoints (`/streaming.mp3` or `/streaming.flac` etc) (#1419)