### PR TITLE
mdns_init: improve error handling (avoid null reference access)

### DIFF
--- a/src/mdns_avahi.c
+++ b/src/mdns_avahi.c
@@ -1044,7 +1044,7 @@ mdns_init(void)
 				 client_callback, NULL, &error);
   if (!mdns_client)
     {
-      DPRINTF(E_WARN, L_MDNS, "mdns_init: Could not create Avahi client: %s\n", MDNSERR);
+      DPRINTF(E_WARN, L_MDNS, "mdns_init: Could not create Avahi client: %s\n", avahi_strerror(error));
 
       return -1;
     }


### PR DESCRIPTION
mdns_init: avoid null reference access
- when avahi client creation fails with mdns_client=null, use `avahi_strerror(error)` instead of `MDNSERR`  to avoid access to `mdns_client->error`.

While testing owntone for synology NAS (https://github.com/SynoCommunity/spksrc/pull/4337) I got an assertion
`owntone: client.c:791: avahi_client_errno: Assertion 'client' failed.`

With this fix I get the correct error message:
`[2022-05-22 20:22:22] [ WARN]     mdns: mdns_init: Could not create Avahi client: Daemon not running`


This does not solve my problem, that no mdns service is running.
Any hint for what I might be missing?

