### PR TITLE
[jsonapi] playlists dir migrated under be under library directories

### DIFF
--- a/owntone.conf.in
+++ b/owntone.conf.in
@@ -218,6 +218,8 @@ library {
 	# A directory in one of the library directories that will be used as the default
 	# playlist directory. OwnTone creates new playlists in this directory if only
 	# a playlist name is provided (requires "allow_modify_stored_playlists" set to true).
+	# This directory is relative to the first library directory
+	# /srv/music/Playlists, you can set this to "/Playlists".
 #	default_playlist_directory = ""
 
 	# By default OwnTone will - like iTunes - clear the playqueue if


### PR DESCRIPTION
Addresses #1485

The server can save user created playlists (typically from the `queue` page) under a directory specified by `default_playlist_directory` - this however is an *absolute* path which is different handling to, say, `podcasts` directory that is *relative* to the `directories` of the server.

This change makes the _playlist directory_ relative to the first library directory.