### PR TITLE
Added avahi-daemon to debian install list

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,7 @@ sudo apt-get install \
   libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev \
   libasound2-dev libmxml-dev libgcrypt20-dev libavahi-client-dev zlib1g-dev \
   libevent-dev libplist-dev libsodium-dev libjson-c-dev libwebsockets-dev \
-  libcurl4-openssl-dev libprotobuf-c-dev
+  libcurl4-openssl-dev libprotobuf-c-dev avahi-daemon
 ```
 
 Note that OwnTone will also work with other versions and flavours of


### PR DESCRIPTION
There is a note at the very end of the file that mentions the avahi daemon is needed.
Pre this change it is not mentioned in the debian notes on starting/monitoring.