### PR TITLE
[web-src] fix to allow reverse proxy from subdirs

### DIFF
--- a/web-src/index.html
+++ b/web-src/index.html
@@ -2,16 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="favicon.ico" />
     <link
       rel="apple-touch-icon"
       sizes="180x180"
-      href="/apple-touch-icon.png?ver=2.0"
+      href="apple-touch-icon.png?ver=2.0"
     />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="manifest" href="/site.webmanifest" />
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
+    <link rel="manifest" href="site.webmanifest" />
+    <link rel="mask-icon" href="safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/web-src/package.json
+++ b/web-src/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "scripts": {
     "serve": "vite",
-    "build": "vite build",
+    "build": "vite build --base='./'",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
     "dev": "vite",
     "format": "prettier .  --write",


### PR DESCRIPTION
cc: @chme 

We can reverse proxy `owntone` by following instructions on the wiki:
https://github.com/owntone/owntone-server/wiki/Creating-a-reverse-proxy-using-NGINX.

but the `index.html` and `vite` generation forces the proxy address be at `/` which is not ideal:  simple change to allow proxying from any subdir:

```
#/etc/nginx.conf
...
http {
  server {
      ...
        location /daap/ {
            proxy_pass http://127.0.0.1:3689/;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
            proxy_http_version 1.1;
            proxy_set_header Upgrade $http_upgrade;
            proxy_set_header Connection "upgrade";
        }
  }
}
``` 