### PR TITLE
[db,scan,jsonapi] bug fix to handle date_released before 1970

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -187,7 +187,7 @@ static const struct col_type_map mfi_cols_map[] =
     { "song_length",        mfi_offsetof(song_length),        DB_TYPE_INT },
     { "file_size",          mfi_offsetof(file_size),          DB_TYPE_INT64 },
     { "year",               mfi_offsetof(year),               DB_TYPE_INT },
-    { "date_released",      mfi_offsetof(date_released),      DB_TYPE_INT },
+    { "date_released",      mfi_offsetof(date_released),      DB_TYPE_INT64 },
     { "track",              mfi_offsetof(track),              DB_TYPE_INT },
     { "total_tracks",       mfi_offsetof(total_tracks),       DB_TYPE_INT },
     { "disc",               mfi_offsetof(disc),               DB_TYPE_INT },

--- a/src/db.h
+++ b/src/db.h
@@ -190,7 +190,7 @@ struct media_file_info {
   uint32_t song_length;
   int64_t file_size;
   uint32_t year;         /* TDRC */
-  uint32_t date_released;
+  int64_t date_released;  // bumped to (signed) int64 since all 32bits are unsigned
 
   uint32_t track;        /* TRCK */
   uint32_t total_tracks;

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -147,7 +147,7 @@ safe_json_add_time_from_string(json_object *obj, const char *key, const char *va
 static inline void
 safe_json_add_date_from_string(json_object *obj, const char *key, const char *value)
 {
-  uint32_t tmp;
+  int64_t tmp;
   time_t timestamp;
   struct tm tm;
   char result[32];
@@ -155,9 +155,9 @@ safe_json_add_date_from_string(json_object *obj, const char *key, const char *va
   if (!value)
     return;
 
-  if (safe_atou32(value, &tmp) != 0)
+  if (safe_atoi64(value, &tmp) != 0)
     {
-      DPRINTF(E_LOG, L_WEB, "Error converting timestamp to uint32_t: %s\n", value);
+      DPRINTF(E_LOG, L_WEB, "Error converting timestamp to int64_t: %s\n", value);
       return;
     }
 

--- a/src/library/filescanner_ffmpeg.c
+++ b/src/library/filescanner_ffmpeg.c
@@ -98,7 +98,8 @@ parse_date(struct media_file_info *mfi, char *date_string)
 {
   char year_string[32];
   uint32_t *year = (uint32_t *) ((char *) mfi + mfi_offsetof(year));
-  uint32_t *date_released = (uint32_t *) ((char *) mfi + mfi_offsetof(date_released));
+  // signed in db.h to handle dates before 1970
+  int64_t *date_released = (int64_t *) ((char *) mfi + mfi_offsetof(date_released));
   struct tm tm = { 0 };
   int ret = 0;
 
@@ -111,7 +112,7 @@ parse_date(struct media_file_info *mfi, char *date_string)
        || strptime(date_string, "%F", &tm)
      )
     {
-      *date_released = (uint32_t)mktime(&tm);
+      *date_released = mktime(&tm);
       ret++;
     }
 
@@ -120,7 +121,7 @@ parse_date(struct media_file_info *mfi, char *date_string)
       snprintf(year_string, sizeof(year_string), "%" PRIu32 "-01-01T12:00:00", *year);
       if (strptime(year_string, "%FT%T", &tm))
 	{
-	  *date_released = (uint32_t)mktime(&tm);
+	  *date_released = mktime(&tm);
 	  ret++;
 	}
     }


### PR DESCRIPTION
Closes #1555

Release date of track is assumed to be >1970 and stored/handled as an `uint32_t` which causes mishandling of dates before unix epoch.  For example, a file with release date of `1960-10-04`, the db stores `date_released` as `4003280896` vs `-291686400` and gets misidenfied as a date in 2096.

I've bumped the storage and handling of `struct media_file_info::date_released` to `int64` since there's a note for all ints to be handled as unsigned. 

Test before and after through json api  (see `date_released`):
* master
```
{
  "id": 47,
  "title": "old song",
  "title_sort": "old song",
  "artist": "foobar",
  "artist_sort": "foobar",
  "album": "nothing good",
  "album_sort": "nothing good",
  "album_id": "2347841309122213946",
  "album_artist": "foobar",
  "album_artist_sort": "foobar",
  "album_artist_id": "7097352992947437494",
  "genre": "Pop",
  "year": 1960,
  "track_number": 1,
  "disc_number": 0,
  "length_ms": 10031,
  "rating": 0,
  "play_count": 0,
  "skip_count": 0,
  "time_added": "2022-12-11T15:51:16Z",
  "date_released": "2096-11-09",
  "seek_ms": 0,
  "type": "mp3",
  "samplerate": 44100,
  "bitrate": 128,
  "channels": 2,
  "usermark": 0,
  "media_kind": "music",
  "data_kind": "file",
  "path": "/home/ray/Music/date1960.mp3",
  "uri": "library:track:47",
  "artwork_url": "/artwork/item/47"
}
```
* after fix
```
{
  "id": 47,
  "title": "old song",
  "title_sort": "old song",
  "artist": "foobar",
  "artist_sort": "foobar",
  "album": "nothing good",
  "album_sort": "nothing good",
  "album_id": "2347841309122213946",
  "album_artist": "foobar",
  "album_artist_sort": "foobar",
  "album_artist_id": "7097352992947437494",
  "genre": "Pop",
  "year": 1960,
  "track_number": 1,
  "disc_number": 0,
  "length_ms": 10031,
  "rating": 0,
  "play_count": 0,
  "skip_count": 0,
  "time_added": "2022-12-11T15:51:16Z",
  "date_released": "1960-10-04",
  "seek_ms": 0,
  "type": "mp3",
  "samplerate": 44100,
  "bitrate": 128,
  "channels": 2,
  "usermark": 0,
  "media_kind": "music",
  "data_kind": "file",
  "path": "/home/ray/Music/date1960.mp3",
  "uri": "library:track:47",
  "artwork_url": "/artwork/item/47"
}
```