### PR TITLE
Error message not displayed

### DIFF
--- a/web-src/src/App.vue
+++ b/web-src/src/App.vue
@@ -128,7 +128,7 @@ export default {
         })
         .catch(() => {
           this.$store.dispatch('add_notification', {
-            text: this.$t('server.connection.failed'),
+            text: this.$t('server.connection-failed'),
             type: 'danger',
             topic: 'connection'
           })


### PR DESCRIPTION
When the connection with the OwnTone server is lost, the error message is not displayed.