### PR TITLE
Allow mixed ipv4/ipv6 mdns

### DIFF
--- a/src/mdns_avahi.c
+++ b/src/mdns_avahi.c
@@ -682,11 +682,15 @@ address_check(const char *hostname, const AvahiAddress *addr, int port, enum mdn
   else
     snprintf(address_log, sizeof(address_log), "[%s]", address);
 
-  if ((addr->proto == AVAHI_PROTO_INET && is_v4ll(&(addr->data.ipv4))) || (addr->proto == AVAHI_PROTO_INET6 && is_v6ll(&(addr->data.ipv6)))) 
-    {
-      DPRINTF(E_WARN, L_MDNS, "Ignoring announcement from %s, address %s is link-local\n", hostname, address_log);
-      return -1;
-    }
+  if (addr->proto == AVAHI_PROTO_INET6 && (flags & MDNS_IPV4ONLY || !cfg_getbool(cfg_getsec(cfg, "general"), "ipv6"))) {
+    DPRINTF(E_WARN, L_MDNS, "Ignoring announcement from %s, address %s is ipv6, but ipv6 is disabled\n", hostname, address_log);
+    return -1;
+  }
+
+  if ((addr->proto == AVAHI_PROTO_INET && is_v4ll(&(addr->data.ipv4))) || (addr->proto == AVAHI_PROTO_INET6 && is_v6ll(&(addr->data.ipv6)))) {
+    DPRINTF(E_WARN, L_MDNS, "Ignoring announcement from %s, address %s is link-local\n", hostname, address_log);
+    return -1;
+  }
 
   if (!(flags & MDNS_CONNECTION_TEST))
     return 0; // All done


### PR DESCRIPTION
This pull request addresses a somewhat obscure issue where ipv4 A records are published over the ipv6 network.

### Background

The MDNS spec allows publishers to publish A records and AAAA records over either ipv4 or ipv6 or both networks. This rarely presents an issue, since most mixed ipv4/ipv6 publishers will publish both A records and AAAA records on both networks, and clients can find whichever one they prefer. In some unusual circumstances, an ipv4 only publisher's ipv4 A record may be broadcast (or received) only over the ipv6 network.

The specific circumstances I am dealing with where this arose is as follows. I recently decided to segregate my iot devices into a separate vlan. This included one of my airplay players -- an old Apple AirPort Express. I also set up my router, a Ubiquiti EdgeRouter 5, to reflect mdns traffic across all the vlans so my computers and phones, which are on a more secure vlan, could still find the airplay players (among other devices). This worked like a charm for the Apple Music app on both computers and phones, but OwnTone running on a linux server could not see the AirPort Express. 

The log file indicated that OwnTone could see the AirPort but when attempting to validate the address, it threw up a getaddrinfo error saying that the address was the wrong type for the address family. A little more digging showed that OwnTone was trying to validate the airport's ipv4 address as an ipv6 address, which of course failed. And running Avahi browse from the command line showed that the ipv4 broadcast was received on the NIC's ipv6 interface. 

I have not analyzed all the mdns traffic to confirm, but I suspect that the router is receiving the ipv4 record from the AirPort on the iot vlan and then rebroadcasting on ipv6 on all the other vlans, but not on ipv4. I'm not sure why it would be doing that, and it may be a bug in the avahi-daemon's reflection implementation, but as explained below, there also seems to be a bug in OwnTone's address validation logic that is preventing it from handling this situation (which, as noted, does not cause problems for the Apple apps). 

### The Solution

OwnTone assumes that when an address resolution callback is received over the ipv6 network, the resolved address will also be ipv6 (and vice-versa). This assumption is operationalized when the `browse_resolve_callback` attempts to validate the address using the `AvahiProtocol` passed to the callback (which indicating where the record was received, but not necessarily the type of address that was received). But the `AvahiAddress` object has its own protocol field, indicating the ip family of the resolved DNS record, and that's what should be used to validate the address. This pull request modifies the `address_check` to use the `proto` field of the `AvahiAddress` record to validate the address rather than the `proto` parameter passed to the callback. 