### PR TITLE
[MPD]: sanitize newline characters in ID3 tag values

### DIFF
--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2721,15 +2721,23 @@ mpd_command_findadd(struct evbuffer *evbuf, int argc, char **argv, char **errmsg
   return 0;
 }
 
-void
+/*
+ * Some MPD clients crash if the tag value includes the newline character.
+ * While they should normally not be included in most ID3 tags, they sometimes
+ * are, so we just change them to space. See #1613 for more details.
+ */
+
+static void
 sanitize_value(char **strval)
 {
   char *ptr = *strval;
 
-  while(*ptr != '\0') {
-    if(*ptr == '\n') {
-      *ptr = ' ';
-    }
+  while(*ptr != '\0')
+    {
+      if(*ptr == '\n')
+  {
+    *ptr = ' ';
+  }
     ptr++;
   }
 }

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2721,6 +2721,19 @@ mpd_command_findadd(struct evbuffer *evbuf, int argc, char **argv, char **errmsg
   return 0;
 }
 
+void
+sanitize_value(char **strval)
+{
+  char *ptr = *strval;
+
+  while(*ptr != '\0') {
+    if(*ptr == '\n') {
+      *ptr = ' ';
+    }
+    ptr++;
+  }
+}
+
 static int
 mpd_command_list(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, struct mpd_client_ctx *ctx)
 {
@@ -2784,6 +2797,7 @@ mpd_command_list(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, s
       if (!(*strval) || (**strval == '\0'))
 	continue;
 
+      sanitize_value(strval);
       evbuffer_add_printf(evbuf,
 			  "%s: %s\n",
 			  tagtype->tag,


### PR DESCRIPTION
Fixes https://github.com/owntone/owntone-server/issues/1613 by replacing newline character with a space.