### PR TITLE
[db,ffmpeg] calculate and persist `audio hash` on local files

### DIFF
--- a/owntone.conf.in
+++ b/owntone.conf.in
@@ -238,6 +238,12 @@ library {
 	# the playlist like MPD does. Note that some dacp clients do not show
 	# the playqueue if playback is stopped.
 #	clear_queue_on_stop_disable = false
+
+	# Enable audio hash persistance for local files
+	# Audio streams of files can be hashed to give identifiers to audio files
+	# that are independant of any metadata, but generation is a more expensive
+	# operation
+#	audio_hash = false
 }
 
 # Local audio output

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -121,6 +121,7 @@ static cfg_opt_t sec_library[] =
     CFG_BOOL("only_first_genre", cfg_false, CFGF_NONE),
     CFG_STR_LIST("decode_audio_filters", NULL, CFGF_NONE),
     CFG_STR_LIST("decode_video_filters", NULL, CFGF_NONE),
+    CFG_BOOL("audio_hash", cfg_false, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/db.c
+++ b/src/db.c
@@ -230,6 +230,7 @@ static const struct col_type_map mfi_cols_map[] =
     { "channels",           mfi_offsetof(channels),           DB_TYPE_INT },
     { "usermark",           mfi_offsetof(usermark),           DB_TYPE_INT },
     { "scan_kind",          mfi_offsetof(scan_kind),          DB_TYPE_INT },
+    { "audio_hash",         mfi_offsetof(audio_hash),         DB_TYPE_STRING },
   };
 
 /* This list must be kept in sync with
@@ -371,6 +372,7 @@ static const ssize_t dbmfi_cols_map[] =
     dbmfi_offsetof(channels),
     dbmfi_offsetof(usermark),
     dbmfi_offsetof(scan_kind),
+    dbmfi_offsetof(audio_hash),
   };
 
 /* This list must be kept in sync with
@@ -777,6 +779,7 @@ free_mfi(struct media_file_info *mfi, int content_only)
   free(mfi->composer_sort);
   free(mfi->album_artist_sort);
   free(mfi->virtual_path);
+  free(mfi->audio_hash);
 
   if (!content_only)
     free(mfi);

--- a/src/db.h
+++ b/src/db.h
@@ -248,6 +248,8 @@ struct media_file_info {
   char *composer_sort;
 
   uint32_t scan_kind; /* Identifies the library_source that created/updates this item */
+
+  char *audio_hash;  /* sha256 - ffmpeg -i foo.mp3 -c:a copy -bsf:a null -f hash - */
 };
 
 #define mfi_offsetof(field) offsetof(struct media_file_info, field)
@@ -422,6 +424,7 @@ struct db_media_file_info {
   char *channels;
   char *usermark;
   char *scan_kind;
+  char *audio_hash;
 };
 
 #define dbmfi_offsetof(field) offsetof(struct db_media_file_info, field)

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -98,7 +98,8 @@
   "   composer_sort      VARCHAR(1024) DEFAULT NULL COLLATE DAAP,"	\
   "   channels           INTEGER DEFAULT 0,"		\
   "   usermark           INTEGER DEFAULT 0,"		\
-  "   scan_kind          INTEGER DEFAULT 0"		\
+  "   scan_kind          INTEGER DEFAULT 0,"		\
+  "   audio_hash         VARCHAR(128) DEFAULT NULL"	\
   ");"
 
 #define T_PL					\

--- a/src/db_init.h
+++ b/src/db_init.h
@@ -26,7 +26,7 @@
  * is a major upgrade. In other words minor version upgrades permit downgrading
  * the server after the database was upgraded. */
 #define SCHEMA_VERSION_MAJOR 22
-#define SCHEMA_VERSION_MINOR 0
+#define SCHEMA_VERSION_MINOR 1
 
 int
 db_init_indices(sqlite3 *hdl);

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1227,6 +1227,21 @@ static const struct db_upgrade_query db_upgrade_v2200_queries[] =
     { U_v2200_SCVER_MINOR,    "set schema_version_minor to 00" },
   };
 
+/* ---------------------------- 22.00 -> 22.01 ------------------------------ */
+#define U_v2201_ALTER_FILES_AUDIOHASH \
+  "ALTER TABLE files ADD COLUMN audio_hash VARCHAR(128) DEFAULT NULL;"
+#define U_v2201_SCVER_MINOR                    \
+  "UPDATE admin SET value = '01' WHERE key = 'schema_version_minor';"
+
+static const struct db_upgrade_query db_upgrade_v2201_queries[] =
+  {
+    { U_v2201_ALTER_FILES_AUDIOHASH, "update files adding audio_hash" },
+
+    { U_v2201_SCVER_MINOR,    "set schema_version_minor to 01" },
+  };
+
+
+
 /* -------------------------- Main upgrade handler -------------------------- */
 
 int
@@ -1437,6 +1452,12 @@ db_upgrade(sqlite3 *hdl, int db_ver)
       if (ret < 0)
 	return -1;
 
+      /* FALLTHROUGH */
+
+    case 2200:
+      ret = db_generic_upgrade(hdl, db_upgrade_v2201_queries, ARRAY_SIZE(db_upgrade_v2201_queries));
+      if (ret < 0)
+	return -1;
 
       /* Last case statement is the only one that ends with a break statement! */
       break;

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -312,6 +312,8 @@ track_to_json(struct db_media_file_info *dbmfi)
   safe_json_add_int_from_string(item, "channels", dbmfi->channels);
   safe_json_add_int_from_string(item, "usermark", dbmfi->usermark);
 
+  safe_json_add_string(item, "audio_hash", dbmfi->audio_hash);
+
   ret = safe_atoi32(dbmfi->media_kind, &intval);
   if (ret == 0)
     safe_json_add_string(item, "media_kind", db_media_kind_label(intval));

--- a/src/parsers/smartpl_lexer.l
+++ b/src/parsers/smartpl_lexer.l
@@ -87,6 +87,7 @@ samplerate     { yylval->str = strdup(yytext); return SMARTPL_T_INTTAG; }
 song_length    { yylval->str = strdup(yytext); return SMARTPL_T_INTTAG; }
 usermark       { yylval->str = strdup(yytext); return SMARTPL_T_INTTAG; }
 file_size      { yylval->str = strdup(yytext); return SMARTPL_T_INTTAG; }
+audio_hash     { yylval->str = strdup(yytext); return SMARTPL_T_STRTAG; }
 
 time_added     { yylval->str = strdup(yytext); return SMARTPL_T_DATETAG; }
 time_modified  { yylval->str = strdup(yytext); return SMARTPL_T_DATETAG; }


### PR DESCRIPTION
Contributing to fixing #85 

* DB - new `audio_hash` column
* scanner - optionally calc audio hash for files  (based on all packets in file)
* json api, conf, smartpl - supporting work