### PR TITLE
Let Github actions rebuild web UI on push to web-src

### DIFF
--- a/.github/workflows/build_htdocs.yml
+++ b/.github/workflows/build_htdocs.yml
@@ -1,0 +1,39 @@
+name: Build htdocs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'web-src/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        working-directory: web-src
+        run: npm install
+
+      # Build for production with minification (will update web interface
+      # in "../htdocs")
+      - name: Build htdocs
+        working-directory: web-src
+        run: npm run build
+
+      - name: Count changed files
+        id: count
+        run: |
+          git add htdocs/
+          git diff --numstat --staged > diffstat
+          test -s diffstat || { echo "Warning: Push to web-src did not change htdocs"; exit 1; }
+
+      # The GH action email is from https://github.com/orgs/community/discussions/26560
+      - name: Commit and push updated assets
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "[web] Rebuild web interface"
+          git push

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,19 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, ]
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'htdocs/**'
+      - 'web-src/**'
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'htdocs/**'
+      - 'web-src/**'
   schedule:
     - cron: '0 19 * * 6'
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,9 +2,19 @@ name: MacOS
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'htdocs/**'
+      - 'web-src/**'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'htdocs/**'
+      - 'web-src/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,9 +2,19 @@ name: Ubuntu
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'htdocs/**'
+      - 'web-src/**'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'htdocs/**'
+      - 'web-src/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
@hacketiwack I think it would be good if Github actions was used to automatically rebuild the web UI whenever a change is pushed to web-src. Thus, there is no relying on the build on a local machine, and the rebuilt UI can be kept out of a PR.

Let me know if you have any concerns about this.