### PR TITLE
[main] Allow specifying the group to use in the configuration file

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -181,7 +181,7 @@ Note: if for some reason you've installed the avahi port, you need to
 add `--without-avahi` to configure above.
 
 Edit `/usr/local/etc/owntone.conf` and change the `uid` to a nice
-system daemon (eg: unknown), and run the following:
+system daemon (eg: unknown) and optionnally the `gid`, and run the following:
 
 ```bash
 sudo mkdir -p /usr/local/var/run

--- a/owntone.conf.in
+++ b/owntone.conf.in
@@ -12,6 +12,11 @@ general {
 	# Make sure the user has read access to the library directories you set
 	# below, and full access to the databases, log and local audio
 	uid = "@OWNTONE_USER@"
+	
+	# User group
+	# The library might be shared by multiple users that all belong to this group. 
+	# Default to the first group declared for the user
+#	gid = "@OWNTONE_USER@"
 
 	# Database location
 #	db_path = "@localstatedir@/cache/@PACKAGE@/songs3.db"

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -45,6 +45,7 @@ static int cb_loglevel(cfg_t *cfg, cfg_opt_t *opt, const char *value, void *resu
 static cfg_opt_t sec_general[] =
   {
     CFG_STR("uid", "nobody", CFGF_NONE),
+    CFG_STR("gid", "", CFGF_NONE),
     CFG_STR("db_path", STATEDIR "/cache/" PACKAGE "/songs3.db", CFGF_NONE),
     CFG_STR("db_backup_path", NULL, CFGF_NONE),
     CFG_STR("logfile", STATEDIR "/log/" PACKAGE ".log", CFGF_NONE),


### PR DESCRIPTION
Fix #1666 

Since owntone allows to specify the user to downgrade to, but not the group, this adds the feature to also specify the group to downgrade to.

This is backward compatible (if the gid option is missing in the owntone.conf file), it fallbacks to the previous behavior that was using the first group for the owntone specified user.