### PR TITLE
[web] Various CSS fixes

### DIFF
--- a/web-src/src/components/LyricsPane.vue
+++ b/web-src/src/components/LyricsPane.vue
@@ -173,6 +173,7 @@ export default {
   left: calc(50% - 50vw);
   width: 100vw;
   height: calc(100vh - 26rem);
+  max-height: min(100% - 8rem, 100vh - 26rem + 3.5rem); /* When the art picture underneath is in portrait rather than landscape, we have to clip the area to the picture height */
   position: absolute;
   overflow: auto;
   --mask: linear-gradient(


### PR DESCRIPTION
There's a bug in the lyrics pane being sometime too big for the covert art underneath.

This happens when the album art aspect ratio is inverted (portrait instead of landscape). Since only one dimension is specified for the image, the other dimension is computed from the aspect ratio. 
Most of the time, the covert is in landscape mode, so the height is what set in the `max-height` property, but when it's in portrait, the max-height property isn't used and the height is smaller.

This changes account for the 2 cases and select the minimum dimension (so the lyrics should never override the time slider).

This fix #1689's remark that I've observed. 