### PR TITLE
[xcode] Support for ALAC encoded RSP/DAAP streaming

### DIFF
--- a/owntone.conf.in
+++ b/owntone.conf.in
@@ -187,19 +187,24 @@ library {
 	# Should we import the content of iTunes smart playlists?
 #	itunes_smartpl = false
 
-	# Decoding options for DAAP and RSP clients
+	# Transcoding options for DAAP and RSP clients
 	# Since iTunes has native support for mpeg, mp4a, mp4v, alac and wav,
-	# such files will be sent as they are. Any other formats will be decoded
-	# to raw wav. If OwnTone detects a non-iTunes DAAP client, it is
-	# assumed to only support mpeg and wav, other formats will be decoded.
-	# Here you can change when to decode. Note that these settings only
-	# affect serving media to DAAP and RSP clients, they have no effect on
+	# such files will be sent as they are. Any other formats will be
+	# transcoded. Some other clients, including Roku/RSP, announce what
+	# formats they support, and the server will transcode to one of those if
+	# necessary. Clients that don't announce supported formats are assumed
+	# to support mpeg (mp3), wav and alac.
+	# Here you can change when and how to transcode. The settings *only*
+	# affect serving audio to DAAP and RSP clients, they have no effect on
 	# direct AirPlay, Chromecast and local audio playback.
 	# Formats: mp4a, mp4v, mpeg, alac, flac, mpc, ogg, wma, wmal, wmav, aif, wav
-	# Formats that should never be decoded
+	# Formats that should never be transcoded
 #	no_decode = { "format", "format" }
-	# Formats that should always be decoded
+	# Formats that should always be transcoded
 #	force_decode = { "format", "format" }
+	# Prefer transcode to wav (default), alac or mpeg (mp3 with the bit rate
+	# configured below in the streaming section)
+#	prefer_format = "format"
 
 	# Set ffmpeg filters (similar to 'ffmpeg -af xxx') that you want the
 	# server to use when decoding files from your library. Examples:

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -111,6 +111,7 @@ static cfg_opt_t sec_library[] =
     CFG_BOOL("itunes_smartpl", cfg_false, CFGF_NONE),
     CFG_STR_LIST("no_decode", NULL, CFGF_NONE),
     CFG_STR_LIST("force_decode", NULL, CFGF_NONE),
+    CFG_STR("prefer_format", NULL, CFGF_NONE),
     CFG_BOOL("pipe_autostart", cfg_true, CFGF_NONE),
     CFG_INT("pipe_sample_rate", 44100, CFGF_NONE),
     CFG_INT("pipe_bits_per_sample", 16, CFGF_NONE),

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -109,18 +109,19 @@ struct stream_ctx {
 
 static const struct content_type_map ext2ctype[] =
   {
-    { ".html", XCODE_NONE, "text/html; charset=utf-8" },
-    { ".xml",  XCODE_NONE, "text/xml; charset=utf-8" },
-    { ".css",  XCODE_NONE, "text/css; charset=utf-8" },
-    { ".txt",  XCODE_NONE, "text/plain; charset=utf-8" },
-    { ".js",   XCODE_NONE, "application/javascript; charset=utf-8" },
-    { ".gif",  XCODE_NONE, "image/gif" },
-    { ".ico",  XCODE_NONE, "image/x-ico" },
-    { ".png",  XCODE_PNG,  "image/png" },
-    { ".jpg",  XCODE_JPEG, "image/jpeg" },
-    { ".mp3",  XCODE_MP3,  "audio/mpeg" },
-    { ".wav",  XCODE_WAV,  "audio/wav" },
-    { NULL,    XCODE_NONE, NULL }
+    { ".html", XCODE_NONE,      "text/html; charset=utf-8" },
+    { ".xml",  XCODE_NONE,      "text/xml; charset=utf-8" },
+    { ".css",  XCODE_NONE,      "text/css; charset=utf-8" },
+    { ".txt",  XCODE_NONE,      "text/plain; charset=utf-8" },
+    { ".js",   XCODE_NONE,      "application/javascript; charset=utf-8" },
+    { ".gif",  XCODE_NONE,      "image/gif" },
+    { ".ico",  XCODE_NONE,      "image/x-ico" },
+    { ".png",  XCODE_PNG,       "image/png" },
+    { ".jpg",  XCODE_JPEG,      "image/jpeg" },
+    { ".mp3",  XCODE_MP3,       "audio/mpeg" },
+    { ".m4a",  XCODE_MP4_ALAC,  "audio/mp4" },
+    { ".wav",  XCODE_WAV,       "audio/wav" },
+    { NULL,    XCODE_NONE,      NULL }
   };
 
 static char webroot_directory[PATH_MAX];
@@ -677,8 +678,8 @@ static struct stream_ctx *
 stream_new_transcode(struct media_file_info *mfi, enum transcode_profile profile, struct httpd_request *hreq,
                      int64_t offset, int64_t end_offset, event_callback_fn stream_cb)
 {
+  struct media_quality quality = { 0 };
   struct stream_ctx *st;
-  struct media_quality quality = { HTTPD_STREAM_SAMPLE_RATE, HTTPD_STREAM_BPS, HTTPD_STREAM_CHANNELS, HTTPD_STREAM_BIT_RATE };
 
   st = stream_new(mfi, hreq, stream_cb);
   if (!st)
@@ -686,6 +687,8 @@ stream_new_transcode(struct media_file_info *mfi, enum transcode_profile profile
       goto error;
     }
 
+  // We use source sample rate etc, but for MP3 we must set a bit rate
+  quality.bit_rate = cfg_getint(cfg_getsec(cfg, "streaming"), "bit_rate");
   st->xcode = transcode_setup(profile, &quality, mfi->data_kind, mfi->path, mfi->song_length);
   if (!st->xcode)
     {

--- a/src/httpd_daap.c
+++ b/src/httpd_daap.c
@@ -1151,7 +1151,7 @@ daap_reply_songlist_generic(struct httpd_request *hreq, int playlist)
   size_t len;
   enum transcode_profile profile;
   struct transcode_metadata_string xcode_metadata;
-  struct media_quality quality = { HTTPD_STREAM_SAMPLE_RATE, HTTPD_STREAM_BPS, HTTPD_STREAM_CHANNELS, HTTPD_STREAM_BIT_RATE };
+  struct media_quality quality = { 0 };
   uint32_t len_ms;
   int nmeta = 0;
   int sort_headers;
@@ -1238,6 +1238,11 @@ daap_reply_songlist_generic(struct httpd_request *hreq, int playlist)
 	{
 	  if (safe_atou32(dbmfi.song_length, &len_ms) < 0)
 	    len_ms = 3 * 60 * 1000; // just a fallback default
+
+	  safe_atoi32(dbmfi.samplerate, &quality.sample_rate);
+	  safe_atoi32(dbmfi.bits_per_sample, &quality.bits_per_sample);
+	  safe_atoi32(dbmfi.channels, &quality.channels);
+	  quality.bit_rate = cfg_getint(cfg_getsec(cfg, "streaming"), "bit_rate");
 
 	  transcode_metadata_strings_set(&xcode_metadata, profile, &quality, len_ms);
 	  dbmfi.type        = xcode_metadata.type;

--- a/src/httpd_internal.h
+++ b/src/httpd_internal.h
@@ -36,11 +36,6 @@
 #define HTTP_BADGATEWAY        502	/**< received an invalid response from the upstream */
 #define HTTP_SERVUNAVAIL       503	/**< the server is not available */
 
-#define HTTPD_STREAM_SAMPLE_RATE 44100
-#define HTTPD_STREAM_BPS         16
-#define HTTPD_STREAM_CHANNELS    2
-#define HTTPD_STREAM_BIT_RATE    320000
-
 
 struct httpd_request;
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -59,6 +59,18 @@ net_is_http_or_https(const char *url);
 
 /* ----------------------- Conversion/hashing/sanitizers -------------------- */
 
+#ifdef HAVE_ENDIAN_H
+# include <endian.h>
+#elif defined(HAVE_SYS_ENDIAN_H)
+# include <sys/endian.h>
+#elif defined(HAVE_LIBKERN_OSBYTEORDER_H)
+#include <libkern/OSByteOrder.h>
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#endif
+
 // Samples to bytes, bytes to samples
 #define STOB(s, bits, c) ((s) * (c) * (bits) / 8)
 #define BTOS(b, bits, c) ((b) / ((c) * (bits) / 8))

--- a/src/outputs/cast.c
+++ b/src/outputs/cast.c
@@ -32,15 +32,7 @@
 #include <ifaddrs.h>
 #include <unistd.h>
 #include <fcntl.h>
-#ifdef HAVE_ENDIAN_H
-# include <endian.h>
-#elif defined(HAVE_SYS_ENDIAN_H)
-# include <sys/endian.h>
-#elif defined(HAVE_LIBKERN_OSBYTEORDER_H)
-#include <libkern/OSByteOrder.h>
-#define htobe32(x) OSSwapHostToBigInt32(x)
-#define be32toh(x) OSSwapBigToHostInt32(x)
-#endif
+
 #include <gnutls/gnutls.h>
 #include <event2/event.h>
 #include <json.h>
@@ -54,6 +46,7 @@
 #include "outputs.h"
 #include "db.h"
 #include "artwork.h"
+#include "misc.h"
 
 #ifdef HAVE_PROTOBUF_OLD
 #include "cast_channel.v0.pb-c.h"

--- a/src/outputs/rtp_common.h
+++ b/src/outputs/rtp_common.h
@@ -5,18 +5,6 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
-#ifdef HAVE_ENDIAN_H
-# include <endian.h>
-#elif defined(HAVE_SYS_ENDIAN_H)
-# include <sys/endian.h>
-#elif defined(HAVE_LIBKERN_OSBYTEORDER_H)
-#include <libkern/OSByteOrder.h>
-#define htobe16(x) OSSwapHostToBigInt16(x)
-#define be16toh(x) OSSwapBigToHostInt16(x)
-#define htobe32(x) OSSwapHostToBigInt32(x)
-#define be32toh(x) OSSwapBigToHostInt32(x)
-#endif
-
 struct rtcp_timestamp
 {
   uint32_t pos;

--- a/src/transcode.c
+++ b/src/transcode.c
@@ -20,8 +20,6 @@
 # include <config.h>
 #endif
 
-#define _GNU_SOURCE // For memmem()
-
 #include <stdio.h>
 #include <stdbool.h>
 #include <string.h>

--- a/src/transcode.h
+++ b/src/transcode.h
@@ -23,10 +23,14 @@ enum transcode_profile
   XCODE_PCM32,
   // Transcodes the best audio stream to MP3
   XCODE_MP3,
-  // Transcodes the best audio stream to OPUS
+  // Transcodes the best audio stream to raw OPUS (no container)
   XCODE_OPUS,
-  // Transcodes the best audio stream to ALAC
+  // Transcodes the best audio stream to raw ALAC (no container)
   XCODE_ALAC,
+  // Transcodes the best audio stream to ALAC in a MP4 container
+  XCODE_MP4_ALAC,
+  // Produces just the header for a MP4 container with ALAC
+  XCODE_MP4_ALAC_HEADER,
   // Transcodes the best audio stream from OGG
   XCODE_OGG,
   // Transcodes the best video stream to JPEG/PNG/VP8
@@ -78,6 +82,9 @@ transcode_decode_setup(enum transcode_profile profile, struct media_quality *qua
 
 struct encode_ctx *
 transcode_encode_setup(enum transcode_profile profile, struct media_quality *quality, struct decode_ctx *src_ctx, int width, int height);
+
+struct encode_ctx *
+transcode_encode_setup_with_io(enum transcode_profile profile, struct media_quality *quality, struct transcode_evbuf_io *evbuf_io, struct decode_ctx *src_ctx, int width, int height);
 
 struct transcode_ctx *
 transcode_setup(enum transcode_profile profile, struct media_quality *quality, enum data_kind data_kind, const char *path, uint32_t len_ms);
@@ -182,9 +189,15 @@ transcode_encode_query(struct encode_ctx *ctx, const char *query);
 struct http_icy_metadata *
 transcode_metadata(struct transcode_ctx *ctx, int *changed);
 
-// When transcoding, we are in essence serving a different source file than the
-// original to the client. So we can't serve some of the file metadata from the
-// filescanner. This function creates strings to be used for override.
+/* When transcoding, we are in essence serving a different source file than the
+ * original to the client. So we can't serve some of the file metadata from the
+ * filescanner. This function creates strings to be used for override.
+ *
+ * @out s          Structure with (non-allocated) strings
+ * @in  profile    Transcoding profile
+ * @in  q          Transcoding quality
+ * @in  len_ms     Length of source track
+ */
 void
 transcode_metadata_strings_set(struct transcode_metadata_string *s, enum transcode_profile profile, struct media_quality *q, uint32_t len_ms);
 


### PR DESCRIPTION
Also changes WAV encoding to use source quality instead of fixed 44100/16/2. Sets the default to WAV, since it has the best quality, and doesn't have the delay that creating an MP4 container for ALAC currently has (TODO prepare the headers to avoid the delay).

Ref issue #1182 and #1665