### PR TITLE
[web] Add sort by artist+title, artist+year options

### DIFF
--- a/web-src/src/i18n/en.json
+++ b/web-src/src/i18n/en.json
@@ -265,7 +265,9 @@
         "title": "Sort",
         "name": "Name",
         "recently-added": "Recently added",
-        "recently-released": "Recently released"
+        "recently-released": "Recently released",
+        "artist-title": "Artist then title",
+        "artist-year": "Artist then year"
       }
     },
     "artist": {

--- a/web-src/src/lib/GroupedList.js
+++ b/web-src/src/lib/GroupedList.js
@@ -108,6 +108,31 @@ export function byDateSinceToday(field, defaultValue = '0000') {
   }
 }
 
+export function byArtistWithSecondary(primary, secondary, defaultValue = '') {
+  return {
+    compareFn: (a, b) => {
+      const fieldA = a[primary] || defaultValue
+      const fieldB = b[primary] || defaultValue
+      if (fieldA === fieldB) {
+        const fieldAA = a[secondary] || defaultValue
+        const fieldBB = b[secondary] || defaultValue
+        return fieldAA.localeCompare(fieldBB, locale.value)
+      }
+      return fieldA.localeCompare(fieldB, locale.value)
+    },
+
+    groupKeyFn: (item) => {
+      const value = (item[primary] || defaultValue).charAt(0)
+      if (value.match(/\p{Letter}/gu)) {
+        return value.toUpperCase()
+      } else if (value.match(/\p{Number}/gu)) {
+        return '#'
+      }
+      return '⌘'
+    }
+  }
+}
+
 export class GroupedList {
   constructor({ items = [], total = 0, offset = 0, limit = -1 } = {}) {
     this.items = items

--- a/web-src/src/pages/PageAlbums.vue
+++ b/web-src/src/pages/PageAlbums.vue
@@ -64,7 +64,7 @@
 
 <script>
 import * as types from '@/store/mutation_types'
-import { GroupedList, byName, byYear } from '@/lib/GroupedList'
+import { GroupedList, byName, byYear, byArtistWithSecondary } from '@/lib/GroupedList'
 import ContentWithHeading from '@/templates/ContentWithHeading.vue'
 import ControlDropdown from '@/components/ControlDropdown.vue'
 import IndexButtonList from '@/components/IndexButtonList.vue'
@@ -128,6 +128,16 @@ export default {
           options: byYear('date_released', {
             direction: 'desc'
           })
+        },
+        {
+          id: 4,
+          name: this.$t('page.albums.sort.artist-title'),
+          options: byArtistWithSecondary('artist', 'name-sort')
+        },
+        {
+          id: 5,
+          name: this.$t('page.albums.sort.artist-year'),
+          options: byArtistWithSecondary('artist', 'date_released')
         }
       ]
     }


### PR DESCRIPTION
I like using a flat view of albums, yet with the ordering being based on the artist's name. This PR adds two options to the sort options for albums, "Artist then title" and "Artist then year".