### PR TITLE
Switch from mxml to libxml2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
     #    uses a compiled language
     - run: |
         sudo apt-get update
-        sudo apt-get install -yq build-essential clang clang-tools git autotools-dev autoconf libtool gettext gawk gperf bison flex libconfuse-dev libunistring-dev libsqlite3-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev libasound2-dev libmxml-dev libgcrypt20-dev libavahi-client-dev zlib1g-dev libevent-dev libplist-dev libsodium-dev libcurl4-openssl-dev libjson-c-dev libprotobuf-c-dev libpulse-dev libwebsockets-dev libgnutls28-dev
+        sudo apt-get install -yq build-essential clang clang-tools git autotools-dev autoconf libtool gettext gawk gperf bison flex libconfuse-dev libunistring-dev libsqlite3-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev libasound2-dev libxml2-dev libgcrypt20-dev libavahi-client-dev zlib1g-dev libevent-dev libplist-dev libsodium-dev libcurl4-openssl-dev libjson-c-dev libprotobuf-c-dev libpulse-dev libwebsockets-dev libgnutls28-dev
         autoreconf -vi
         ./configure --enable-lastfm --enable-chromecast
         scan-build --status-bugs -disable-checker deadcode.DeadStores --exclude src/parsers make

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,12 +38,6 @@ jobs:
         sudo ln -s /usr/local/opt/bison/bin/bison /usr/local/bin/bison
         sudo ln -s /usr/local/opt/flex/bin/flex /usr/local/bin/flex
 
-    - name: Install libmxml
-      # Homebrew by default comes with libmxml 4, but it isn't compatible with mxml 3 which we need
-      run: |
-        wget https://raw.githubusercontent.com/Homebrew/homebrew-core/71bfcd3624ee88eee1e2ea6653753dafd48e7fcf/Formula/lib/libmxml.rb
-        brew install --build-from-source libmxml.rb
-
     - name: Install libinotify-kqueue
       # brew does not have libinotify package
       run: |
@@ -76,7 +70,7 @@ jobs:
 
     - name: Install other dependencies
       run: |
-        brew install libunistring confuse libplist libwebsockets libevent libgcrypt json-c protobuf-c libsodium gnutls pulseaudio openssl
+        brew install libxml2 libunistring confuse libplist libwebsockets libevent libgcrypt json-c protobuf-c libsodium gnutls pulseaudio openssl
 
     - name: Configure
       # We configure a non-privileged setup, since how to add a "owntone" system

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -yq build-essential clang clang-tools git autotools-dev autoconf libtool gettext gawk gperf bison flex libconfuse-dev libunistring-dev libsqlite3-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev libasound2-dev libmxml-dev libgcrypt20-dev libavahi-client-dev zlib1g-dev libevent-dev libplist-dev libsodium-dev libcurl4-openssl-dev libjson-c-dev libprotobuf-c-dev libpulse-dev libwebsockets-dev libgnutls28-dev
+        sudo apt-get install -yq build-essential clang clang-tools git autotools-dev autoconf libtool gettext gawk gperf bison flex libconfuse-dev libunistring-dev libsqlite3-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev libasound2-dev libxml2-dev libgcrypt20-dev libavahi-client-dev zlib1g-dev libevent-dev libplist-dev libsodium-dev libcurl4-openssl-dev libjson-c-dev libprotobuf-c-dev libpulse-dev libwebsockets-dev libgnutls28-dev
 
     - name: Build and check
       run: |

--- a/configure.ac
+++ b/configure.ac
@@ -120,13 +120,7 @@ OWNTONE_MODULES_CHECK([OWNTONE], [ZLIB], [zlib], [deflate], [zlib.h])
 OWNTONE_MODULES_CHECK([OWNTONE], [CONFUSE], [libconfuse >= 3.0], [cfg_init], [confuse.h])
 OWNTONE_MODULES_CHECK([OWNTONE], [LIBCURL], [libcurl], [curl_global_init], [curl/curl.h])
 OWNTONE_MODULES_CHECK([OWNTONE], [LIBSODIUM], [libsodium], [sodium_init], [sodium.h])
-
-OWNTONE_MODULES_CHECK([OWNTONE], [MINIXML], [mxml],
-	[mxmlNewElement], [mxml.h],
-	[
-	 dnl See mxml-compat.h
-	 AC_CHECK_FUNCS([mxmlGetOpaque] [mxmlGetText] [mxmlGetType] [mxmlGetFirstChild])
-	])
+OWNTONE_MODULES_CHECK([OWNTONE], [LIBXML2], [libxml-2.0], [xmlInitParser], [libxml/parser.h])
 
 OWNTONE_MODULES_CHECK([COMMON], [SQLITE3], [sqlite3 >= 3.5.0],
 	[sqlite3_initialize], [sqlite3.h],

--- a/docs/building.md
+++ b/docs/building.md
@@ -15,7 +15,7 @@ sudo apt-get install \
   build-essential git autotools-dev autoconf automake libtool gettext gawk \
   gperf bison flex libconfuse-dev libunistring-dev libsqlite3-dev \
   libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev \
-  libasound2-dev libmxml-dev libgcrypt20-dev libavahi-client-dev zlib1g-dev \
+  libasound2-dev libxml2-dev libgcrypt20-dev libavahi-client-dev zlib1g-dev \
   libevent-dev libplist-dev libsodium-dev libjson-c-dev libwebsockets-dev \
   libcurl4-openssl-dev libprotobuf-c-dev
 ```
@@ -73,7 +73,7 @@ will need ffmpeg. You can google how to do that. Then run:
 ```bash
 sudo dnf install \
   git automake autoconf gettext-devel gperf gawk libtool bison flex \
-  sqlite-devel libconfuse-devel libunistring-devel mxml-devel libevent-devel \
+  sqlite-devel libconfuse-devel libunistring-devel libxml2-devel libevent-devel \
   avahi-devel libgcrypt-devel zlib-devel alsa-lib-devel ffmpeg-devel \
   libplist-devel libsodium-devel json-c-devel libwebsockets-devel \
   libcurl-devel protobuf-c-devel
@@ -137,10 +137,8 @@ Install MacPorts (which requires Xcode): <https://www.macports.org/install.php>
 sudo port install \
   autoconf automake libtool pkgconfig git gperf bison flex libgcrypt \
   libunistring libconfuse ffmpeg libevent json-c libwebsockets curl \
-  libplist libsodium protobuf-c
+  libplist libsodium protobuf-c libxml2
 ```
-
-Download, configure, build, and install the [Mini-XML library](https://www.msweet.org/mxml/)
 
 Download, configure, build and install the [libinotify-kqueue library](https://github.com/libinotify-kqueue/libinotify-kqueue)
 
@@ -226,7 +224,7 @@ Libraries:
 - [FFmpeg](https://ffmpeg.org/)
 - [libconfuse](https://github.com/libconfuse/libconfuse)  
 - [libevent](https://libevent.org/) 2.1.4+
-- [Mini-XML](https://www.msweet.org/mxml/) (aka mxml or libmxml)  
+- [libxml2](https://gitlab.gnome.org/GNOME/libxml2)  
 - [Libgcrypt](https://gnupg.org/software/libgcrypt/) 1.2.0+  
 - [zlib](https://zlib.net/)
 - [libunistring](https://www.gnu.org/software/libunistring/) 0.9.3+

--- a/owntone.spec.in
+++ b/owntone.spec.in
@@ -19,7 +19,7 @@ Url: https://github.com/owntone/owntone-server
 Source0: https://github.com/owntone/%{name}/archive/%{version}/%{name}-%{version}.tar.xz
 %{?systemd_ordering}
 BuildRequires: gcc, make, bison, flex, systemd, pkgconfig, libunistring-devel
-BuildRequires: pkgconfig(zlib), pkgconfig(libconfuse), pkgconfig(mxml)
+BuildRequires: pkgconfig(zlib), pkgconfig(libconfuse), pkgconfig(libxml2)
 BuildRequires: pkgconfig(sqlite3) >= 3.5.0, pkgconfig(libevent) >= 2.0.0
 BuildRequires: pkgconfig(json-c), libgcrypt-devel >= 1.2.0
 BuildRequires: libgpg-error-devel >= 1.6

--- a/scripts/freebsd_install.sh
+++ b/scripts/freebsd_install.sh
@@ -20,7 +20,7 @@ if [ "$yn" != "y" ]; then
 fi
 
 DEPS="gmake autoconf automake libtool gettext gperf glib pkgconf wget git \
-     ffmpeg libconfuse libevent mxml libgcrypt libunistring libiconv curl \
+     ffmpeg libconfuse libevent libxml2 libgcrypt libunistring libiconv curl \
      libplist libinotify avahi sqlite3 alsa-lib libsodium json-c libwebsockets
      protobuf-c bison flex"
 echo "The script can install the following dependency packages for you:"

--- a/src/misc_xml.h
+++ b/src/misc_xml.h
@@ -1,55 +1,43 @@
 #ifndef SRC_MISC_XML_H_
 #define SRC_MISC_XML_H_
 
-// This wraps mxml and adds some convenience functions. This also means that
-// callers don't need to concern themselves with changes and bugs in various
-// versions of mxml.
+// This wraps libxml2 and adds some convenience functions
 
 typedef void xml_node;
 
-// Wraps mxmlSaveAllocString. Returns NULL on error.
 char *
-xml_to_string(xml_node *top);
+xml_to_string(xml_node *top, const char *xml_declaration);
 
-// Wraps mxmlNewXML and mxmlLoadString, so creates an xml struct with the parsed
-// content of string. Returns NULL on error.
 xml_node *
 xml_from_string(const char *string);
 
-// Wraps mxmlNewXML and mxmlLoadFile, so creates an xml struct with the parsed
-// content of string. Returns NULL on error.
 xml_node *
 xml_from_file(const char *path);
 
-// Wraps mxmlDelete, which will free node + underlying nodes
 void
 xml_free(xml_node *top);
 
-// Wraps mxmlFindPath.
 xml_node *
 xml_get_node(xml_node *top, const char *path);
 
-// Wraps mxmlGetNextSibling, but only returns sibling nodes that have the same
-// name as input node.
+// Only returns sibling nodes that have the same name as input node
 xml_node *
 xml_get_next(xml_node *top, xml_node *node);
 
-// Wraps mxmlFindPath and mxmlGetOpaque + mxmlGetCDATA. Returns NULL if nothing
-// can be found.
 const char *
 xml_get_val(xml_node *top, const char *path);
 
-// Wraps mxmlFindPath and mxmlElementGetAttr. Returns NULL if nothing can be
-// found.
 const char *
 xml_get_attr(xml_node *top, const char *path, const char *name);
 
+// Will create a new XML document with the node as root if parent is NULL
 xml_node *
 xml_new_node(xml_node *parent, const char *name, const char *val);
 
 xml_node *
 xml_new_node_textf(xml_node *parent, const char *name, const char *format, ...);
 
+// Adds a text node to parent, which must be an element node
 void
 xml_new_text(xml_node *parent, const char *val);
 


### PR DESCRIPTION
mxml 4 is binary and source incompatible with 3, and there is no easy way to stay compatible with both. Not great for a library. So replace with libxml2, hopefully that is more stable. Also means we can get rid of all the mxml hacks.