### PR TITLE
mpd: mimick httpd plugin as output

### DIFF
--- a/owntone.conf.in
+++ b/owntone.conf.in
@@ -437,6 +437,10 @@ mpd {
 	# clients and will need additional configuration in the MPD client to
 	# work). Set to 0 to disable serving artwork over http.
 #	http_port = 0
+
+	# Whether to emit an output with plugin type "httpd" to tell clients
+	# that a stream is available for local playback.
+#	enable_httpd_plugin = false
 }
 
 # SQLite configuration (allows to modify the operation of the SQLite databases)

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -238,6 +238,7 @@ static cfg_opt_t sec_mpd[] =
   {
     CFG_INT("port", 6600, CFGF_NONE),
     CFG_INT("http_port", 0, CFGF_NONE),
+    CFG_BOOL("enable_httpd_plugin", cfg_false, CFGF_NONE),
     CFG_BOOL("clear_queue_on_stop_disable", cfg_false, CFGF_NODEFAULT | CFGF_DEPRECATED),
     CFG_BOOL("allow_modifying_stored_playlists", cfg_false, CFGF_NODEFAULT | CFGF_DEPRECATED),
     CFG_STR("default_playlist_directory", NULL, CFGF_NODEFAULT | CFGF_DEPRECATED),

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -77,6 +77,7 @@ static struct evhttp *evhttpd;
 static struct evconnlistener *mpd_listener;
 static int mpd_sockfd;
 
+static bool mpd_plugin_httpd;
 
 // Virtual path to the default playlist directory
 static char *default_pl_dir;
@@ -4858,6 +4859,8 @@ mpd_init(void)
   pl_dir = cfg_getstr(cfg_getsec(cfg, "library"), "default_playlist_directory");
   if (pl_dir)
     default_pl_dir = safe_asprintf("/file:%s", pl_dir);
+
+  mpd_plugin_httpd = cfg_getbool(cfg_getsec(cfg, "mpd"), "enable_httpd_plugin");
 
   /* Handle deprecated config options */
   if (0 < cfg_opt_size(cfg_getopt(cfg_getsec(cfg, "mpd"), "allow_modifying_stored_playlists")))

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3793,6 +3793,19 @@ mpd_command_outputs(struct evbuffer *evbuf, int argc, char **argv, char **errmsg
 
   player_speaker_enumerate(speaker_enum_cb, &param);
 
+  /* streaming output is not in the speaker list, so add it as pseudo
+   * element when configured to do so */
+  if (mpd_plugin_httpd)
+    {
+      evbuffer_add_printf(evbuf,
+		      	  "outputid: %u\n"
+		      	  "outputname: MP3 stream\n"
+		      	  "plugin: httpd\n"
+		      	  "outputenabled: 1\n",
+		      	  param.nextid);
+      param.nextid++;
+    }
+
   return 0;
 }
 


### PR DESCRIPTION
MPD produces the following entry on outputs command:

OK MPD 0.23.5
outputs
outputid: 0
outputname: MP3 stream
plugin: httpd
outputenabled: 1
OK

This indicates to some clients that a HTTP stream is available, and without it they will refuse to do any config/support for it (if at all). While this stream normally would be available on port 8000 that is something that can easily be directed to stream.mp3 using a proxy in front.

Faking this "plugin" simply allows some client to make use of owntone's http stream.