### PR TITLE
[mpd] add binarylimit command (still unused)

### DIFF
--- a/src/mpd.c
+++ b/src/mpd.c
@@ -4615,7 +4615,7 @@ mpd_accept_conn_cb(struct evconnlistener *listener,
    * According to the mpd protocol send "OK MPD <version>\n" to the client, where version is the version
    * of the supported mpd protocol and not the server version.
    */
-  evbuffer_add(bufferevent_get_output(bev), "OK MPD 0.21.0\n", 14);
+  evbuffer_add(bufferevent_get_output(bev), "OK MPD 0.22.4\n", 14);
   client_ctx->evbuffer = bufferevent_get_output(bev);
 
   DPRINTF(E_INFO, L_MPD, "New mpd client connection accepted\n");


### PR DESCRIPTION
Maintain the binary limit, and use the default MPD uses too.  This comes in handy when we are going to send binary responses such as in PR#1780