### PR TITLE
[websocket] avoid crash when websocket port can't be bound

### DIFF
--- a/src/websocket.c
+++ b/src/websocket.c
@@ -516,6 +516,7 @@ websocket_init(void)
     {
       DPRINTF(E_LOG, L_WEB, "Failed to initialize mutex: %s\n", strerror(ret));
       lws_context_destroy(context);
+      context = NULL;
       return -1;
     }
 
@@ -525,6 +526,7 @@ websocket_init(void)
       DPRINTF(E_LOG, L_WEB, "Could not spawn websocket thread (%d): %s\n", ret, strerror(ret));
       pthread_mutex_destroy(&websocket_write_event_lock);
       lws_context_destroy(context);
+      context = NULL;
       return -1;
     }
 
@@ -542,11 +544,15 @@ websocket_deinit(void)
     return;
 
   websocket_exit = true;
-  lws_cancel_service(context);
-  ret = pthread_join(tid_websocket, NULL);
-  if (ret < 0)
-    DPRINTF(E_LOG, L_WEB, "Error joining websocket thread (%d): %s\n", ret, strerror(ret));
+  if (context != NULL)
+    {
+      lws_cancel_service(context);
+      ret = pthread_join(tid_websocket, NULL);
+      if (ret < 0)
+      	DPRINTF(E_LOG, L_WEB, "Error joining websocket thread (%d): %s\n",
+      		ret, strerror(ret));
 
-  lws_context_destroy(context);
-  pthread_mutex_destroy(&websocket_write_event_lock);
+      lws_context_destroy(context);
+      pthread_mutex_destroy(&websocket_write_event_lock);
+    }
 }


### PR DESCRIPTION
Simply using an unavailable port for websocket will make owntone crash during startup because it tries to cleanup resources that are not initialised at all.

Be a bit more careful during deinit so we exit a bit more gracefully on this error condition.