### PR TITLE
[mpd] outputs: drop invalid outputsvolume key

### DIFF
--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3772,8 +3772,7 @@ mpd_command_toggleoutput(struct evbuffer *evbuf, int argc, char **argv, char **e
  *   outputname: Computer
  *   plugin: alsa
  *   outputenabled: 1
- *   outputvolume: 50
- * https://mpd.readthedocs.io/en/latest/protocol.html#audio-output-devices
+ * https://mpd.readthedocs.io/en/latest/protocol.html#command-outputs
  */
 static void
 speaker_enum_cb(struct player_speaker_info *spk, void *arg)
@@ -3798,13 +3797,11 @@ speaker_enum_cb(struct player_speaker_info *spk, void *arg)
 		      "outputid: %u\n"
 		      "outputname: %s\n"
 		      "plugin: %s\n"
-		      "outputenabled: %d\n"
-		      "outputvolume: %d\n",
+		      "outputenabled: %d\n",
 		      param->nextid,
 		      spk->name,
 		      plugin,
-		      spk->selected,
-		      spk->absvol);
+		      spk->selected);
   param->nextid++;
 }
 


### PR DESCRIPTION
This key confuses some clients, and it isn't emitted by MPD, nor documented to exist:
https://github.com/MusicPlayerDaemon/MPD/blob/9ff8e02e543ede2b1964e5ea3f26f00bf2ff90ec/src/output/Print.cxx

It was added in bdb2c7493, but without explanation why it was added to outputs command.