### PR TITLE
Correct libxml2 BuildRequires in spec file

### DIFF
--- a/owntone.spec.in
+++ b/owntone.spec.in
@@ -19,7 +19,7 @@ Url: https://github.com/owntone/owntone-server
 Source0: https://github.com/owntone/%{name}/archive/%{version}/%{name}-%{version}.tar.xz
 %{?systemd_ordering}
 BuildRequires: gcc, make, bison, flex, systemd, pkgconfig, libunistring-devel
-BuildRequires: pkgconfig(zlib), pkgconfig(libconfuse), pkgconfig(libxml2)
+BuildRequires: pkgconfig(zlib), pkgconfig(libconfuse), pkgconfig(libxml-2.0)
 BuildRequires: pkgconfig(sqlite3) >= 3.5.0, pkgconfig(libevent) >= 2.0.0
 BuildRequires: pkgconfig(json-c), libgcrypt-devel >= 1.2.0
 BuildRequires: libgpg-error-devel >= 1.6


### PR DESCRIPTION
The rpm spec file contains a BuildRequires of pkgconfig(libxml2), but the libxml2-devel package has a Provides of pkgconfig(libxml-2.0)

This patch to spec file to update the BuildRequires to use that value.
