### PR TITLE
fix: Now Playing does not stop play progress updates when pausing

### DIFF
--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -145,15 +145,15 @@ export default {
   },
 
   watch: {
-    playerStore() {
+    'playerStore.state'(newState) {
       if (this.interval_id > 0) {
         window.clearTimeout(this.interval_id)
         this.interval_id = 0
       }
-      if (this.playerStore.state === 'play') {
+      if (newState === 'play') {
         this.interval_id = window.setInterval(this.tick, INTERVAL)
       }
-    }
+    },
   },
 
   created() {


### PR DESCRIPTION
I noticed, that when you are on the "now playing" page in the web interface and hit the pause button, the track progress bar keeps updating.

After debugging it, this happens because the "watch" for "playerStore" is never triggered. Watching only the "state" property instead of the whole store object, fixes it - though I am not sure why watching the store does not work in the first place ...