### PR TITLE
[configure] Fix AC_TRY_LINK warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,7 @@ If you modify any .gperf files, you will need to install it.]])],
 		[AC_MSG_ERROR([[GNU gperf required, please install it.]])])
 	])
 
+dnl Avoid deprecation warning by specifying noyywrap explicitly.
 AC_PROG_LEX([noyywrap])
 AX_PROG_FLEX([AC_DEFINE([LEX], [flex], [flex found])],
 	[AS_IF([test ! -f "$srcdir/src/parsers/smartpl_lexer.c"],

--- a/configure.ac
+++ b/configure.ac
@@ -31,8 +31,6 @@ If you modify any .gperf files, you will need to install it.]])],
 		[AC_MSG_ERROR([[GNU gperf required, please install it.]])])
 	])
 
-dnl Avoid deprecation warning by specifying noyywrap explicitly.
-AC_PROG_LEX([noyywrap])
 AX_PROG_FLEX([AC_DEFINE([LEX], [flex], [flex found])],
 	[AS_IF([test ! -f "$srcdir/src/parsers/smartpl_lexer.c"],
 		[AC_MSG_ERROR([flex required, please install it])])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.71])
+AC_PREREQ([2.60])
 AC_INIT([owntone], [28.10])
 
 AC_CONFIG_SRCDIR([config.h.in])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.60])
+AC_PREREQ([2.71])
 AC_INIT([owntone], [28.10])
 
 AC_CONFIG_SRCDIR([config.h.in])
@@ -31,6 +31,7 @@ If you modify any .gperf files, you will need to install it.]])],
 		[AC_MSG_ERROR([[GNU gperf required, please install it.]])])
 	])
 
+AC_PROG_LEX([noyywrap])
 AX_PROG_FLEX([AC_DEFINE([LEX], [flex], [flex found])],
 	[AS_IF([test ! -f "$srcdir/src/parsers/smartpl_lexer.c"],
 		[AC_MSG_ERROR([flex required, please install it])])
@@ -77,8 +78,8 @@ AC_SEARCH_LIBS([pthread_exit], [pthread], [],
 AC_SEARCH_LIBS([pthread_setname_np], [pthread],
 	[dnl Validate pthread_setname_np with 2 args (some have 1)
 	 AC_MSG_CHECKING([[for two-parameter pthread_setname_np]])
-	 AC_TRY_LINK([@%:@include <pthread.h>],
-		[pthread_setname_np(pthread_self(), "name");],
+	 AC_LINK_IFELSE([AC_LANG_PROGRAM([[@%:@include <pthread.h>]],
+		[[pthread_setname_np(pthread_self(), "name");]])],
 		[AC_MSG_RESULT([yes])
 		 AC_DEFINE([HAVE_PTHREAD_SETNAME_NP], 1,
 			[Define to 1 if you have pthread_setname_np])],


### PR DESCRIPTION
During configuration (`autoreconf`) step of the make process, some warnings are displayed, as depicted below.

```log
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: copying file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
configure.ac:34: warning: AC_PROG_LEX without either yywrap or noyywrap is obsolete
./lib/autoconf/programs.m4:716: _AC_PROG_LEX is expanded from...
./lib/autoconf/programs.m4:709: AC_PROG_LEX is expanded from...
aclocal.m4:3686: AM_PROG_LEX is expanded from...
m4/ax_prog_flex.m4:47: AX_PROG_FLEX is expanded from...
configure.ac:34: the top level
configure.ac:77: warning: The macro `AC_TRY_LINK' is obsolete.
configure.ac:77: You should run autoupdate.
./lib/autoconf/general.m4:2920: AC_TRY_LINK is expanded from...
lib/m4sugar/m4sh.m4:699: AS_IF is expanded from...
./lib/autoconf/libs.m4:47: AC_SEARCH_LIBS is expanded from...
configure.ac:77: the top level
configure.ac:14: installing 'build-aux/compile'
configure.ac:10: installing 'build-aux/missing'
sqlext/Makefile.am: installing 'build-aux/depcomp'
```

These little changes remove two warnings:

- ``The macro `AC_TRY_LINK' is obsolete``
- `AC_PROG_LEX without either yywrap or noyywrap is obsolete`
