### PR TITLE
feat: Support for additional metadata and multi-value metadata (genre, composer)

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -118,6 +118,8 @@ struct db_statements
 
   sqlite3_stmt *queue_items_insert;
   sqlite3_stmt *queue_items_update;
+
+  sqlite3_stmt *files_metadata_insert;
 };
 
 struct col_type_map {
@@ -146,6 +148,7 @@ struct fixup_ctx
 };
 
 struct query_clause {
+  char *join;
   char *where;
   char *group;
   char *having;
@@ -155,6 +158,7 @@ struct query_clause {
 
 struct browse_clause {
   char *select;
+  char *from;
   char *where;
   char *group;
 };
@@ -302,6 +306,20 @@ static const struct col_type_map qi_cols_map[] =
   };
 
 /* This list must be kept in sync with
+ * - the order of the columns in the files_metadata table
+ * - the type and name of the fields in struct media_file_metadata_info
+ */
+static const struct col_type_map mfmi_cols_map[] =
+  {
+    { "file_id",       mfmi_offsetof(file_id),        DB_TYPE_INT,    DB_FIXUP_STANDARD },
+    { "songalbumid",   mfmi_offsetof(songalbumid),    DB_TYPE_INT64 },
+    { "songartistid",  mfmi_offsetof(songartistid),   DB_TYPE_INT64 },
+    { "metadata_kind", mfmi_offsetof(metadata_kind),  DB_TYPE_INT },
+    { "idx",           mfmi_offsetof(idx),            DB_TYPE_INT },
+    { "value",         mfmi_offsetof(value),          DB_TYPE_STRING },
+  };
+
+/* This list must be kept in sync with
  * - the order of the columns in the files table
  * - the name of the fields in struct db_media_file_info
  */
@@ -427,6 +445,21 @@ static const ssize_t dbgri_cols_map[] =
     dbgri_offsetof(seek),
   };
 
+
+/* This list must be kept in sync with
+ * - the order of the columns in the files_metadata table
+ * - the name of the fields in struct db_media_file_metadata_info
+ */
+static const ssize_t dbmfmi_cols_map[] =
+  {
+    dbmfmi_offsetof(file_id),
+    dbmfmi_offsetof(songalbumid),
+    dbmfmi_offsetof(songartistid),
+    dbmfmi_offsetof(metadata_kind),
+    dbmfmi_offsetof(idx),
+    dbmfmi_offsetof(value),
+  };
+
 /* This list must be kept in sync with
  * - the order of fields in the Q_BROWSE_INFO query
  * - the name of the fields in struct db_browse_info
@@ -514,6 +547,7 @@ static const char *sort_clause[] =
     "pos",
     "shuffle_pos",
     "f.date_released DESC, f.title_sort DESC",
+    "m.value",
   };
 
 /* Browse clauses, used for SELECT, WHERE, GROUP BY and for default ORDER BY
@@ -522,16 +556,18 @@ static const char *sort_clause[] =
  */
 static const struct browse_clause browse_clause[] =
   {
-    { "",                                      "",                 "" },
-    { "f.album_artist, f.album_artist_sort",   "f.album_artist",   "f.album_artist_sort, f.album_artist" },
-    { "f.album, f.album_sort",                 "f.album",          "f.album_sort, f.album" },
-    { "f.genre, f.genre",                      "f.genre",          "f.genre" },
-    { "f.composer, f.composer_sort",           "f.composer",       "f.composer_sort, f.composer" },
-    { "f.year, f.year",                        "f.year",           "f.year" },
-    { "f.disc, f.disc",                        "f.disc",           "f.disc" },
-    { "f.track, f.track",                      "f.track",          "f.track" },
-    { "f.virtual_path, f.virtual_path",        "f.virtual_path",   "f.virtual_path" },
-    { "f.path, f.path",                        "f.path",           "f.path" },
+    { "",                                      "",   "",                 "" },
+    { "f.album_artist, f.album_artist_sort",   "",   "f.album_artist",   "f.album_artist_sort, f.album_artist" },
+    { "f.album, f.album_sort",                 "",   "f.album",          "f.album_sort, f.album" },
+    { "f.genre, f.genre",                      "",   "f.genre",          "f.genre" },
+    { "f.composer, f.composer_sort",           "",   "f.composer",       "f.composer_sort, f.composer" },
+    { "f.year, f.year",                        "",   "f.year",           "f.year" },
+    { "f.disc, f.disc",                        "",   "f.disc",           "f.disc" },
+    { "f.track, f.track",                      "",   "f.track",          "f.track" },
+    { "f.virtual_path, f.virtual_path",        "",   "f.virtual_path",   "f.virtual_path" },
+    { "f.path, f.path",                        "",   "f.path",           "f.path" },
+    { "m.value, m.value",                      "JOIN files_metadata m ON f.id = m.file_id",   "m.metadata_kind = 1 AND m.value",          "m.value" },
+    { "m.value, m.value",                      "JOIN files_metadata m ON f.id = m.file_id",   "m.metadata_kind = 5 AND m.value",          "m.value" },
   };
 
 
@@ -643,6 +679,28 @@ db_pl_type_label(enum pl_type pl_type)
   if (pl_type < ARRAY_SIZE(pl_type_label))
     {
       return pl_type_label[pl_type];
+    }
+
+  return NULL;
+}
+
+/* Keep in sync with enum metadata_kind */
+static struct metadata_kind_info metadata_infos[] = 
+  {
+    { "lyrics", 0 },
+    { "genre",  1 },
+    { "musicbrainz_albumid", 0 },
+    { "musicbrainz_artistid", 0 },
+    { "musicbrainz_albumartistid", 0 },
+    { "composer",  1 },
+  };
+
+const struct metadata_kind_info *
+db_metadata_kind_info_get(enum metadata_kind metadata_kind)
+{
+  if (metadata_kind < ARRAY_SIZE(metadata_infos))
+    {
+      return &metadata_infos[metadata_kind];
     }
 
   return NULL;
@@ -789,6 +847,36 @@ free_mfi(struct media_file_info *mfi, int content_only)
 }
 
 void
+free_mfmi(struct media_file_metadata_info *mfi_extra_md, int content_only)
+{
+  if (!mfi_extra_md)
+    return;
+
+  free(mfi_extra_md->value);
+
+  if (!content_only)
+    free(mfi_extra_md);
+  else
+    memset(mfi_extra_md, 0, sizeof(struct media_file_metadata_info));
+}
+
+void
+free_mfmi_list(struct media_file_metadata_info **mfmi, int content_only)
+{
+  struct media_file_metadata_info *next;
+
+  if (!mfmi)
+    return;
+
+  while (*mfmi)
+    {
+      next = (*mfmi)->next;
+      free_mfmi(*mfmi, content_only);
+      *mfmi = next;
+    }
+}
+
+void
 free_pli(struct playlist_info *pli, int content_only)
 {
   if (!pli)
@@ -846,6 +934,7 @@ free_query_params(struct query_params *qp, int content_only)
   free(qp->having);
   free(qp->order);
   free(qp->group);
+  free(qp->join);
 
   if (!content_only)
     free(qp);
@@ -1435,6 +1524,12 @@ bind_qi(sqlite3_stmt *stmt, struct db_queue_item *qi)
   return bind_generic(stmt, qi, qi_cols_map, ARRAY_SIZE(qi_cols_map), qi->id);
 }
 
+static int
+bind_mfmi(sqlite3_stmt *stmt, struct media_file_metadata_info *mfmi)
+{
+  return bind_generic(stmt, mfmi, mfmi_cols_map, ARRAY_SIZE(mfmi_cols_map), 0);
+}
+
 /* Unlock notification support */
 static void
 unlock_notify_cb(void **args, int nargs)
@@ -1963,6 +2058,7 @@ db_free_query_clause(struct query_clause *qc)
   if (!qc)
     return;
 
+  sqlite3_free(qc->join);
   sqlite3_free(qc->where);
   sqlite3_free(qc->group);
   sqlite3_free(qc->having);
@@ -2011,6 +2107,11 @@ db_build_query_clause(struct query_params *qp)
     qc->order = sqlite3_mprintf("ORDER BY %s", browse_clause[qp->type & ~Q_F_BROWSE].group);
   else
     qc->order = sqlite3_mprintf("");
+
+  if (qp->join)
+    qc->join = sqlite3_mprintf("%s", qp->join);
+  else
+    qc->join = sqlite3_mprintf("");
 
   switch (qp->idx_type)
     {
@@ -2235,20 +2336,32 @@ db_build_query_plitems(struct query_params *qp, struct query_clause *qc)
 }
 
 static char *
+db_build_query_file_metadata(struct query_params *qp, struct query_clause *qc)
+{
+  char *count;
+  char *query;
+
+  count = sqlite3_mprintf("SELECT COUNT(*) FROM files_metadata fm JOIN files f ON fm.file_id = f.id %s AND fm.file_id = %d;", qc->where, qp->id);
+  query = sqlite3_mprintf("SELECT fm.* FROM files_metadata fm JOIN files f ON fm.file_id = f.id %s AND fm.file_id = %d ORDER BY fm.metadata_kind ASC, fm.idx ASC %s;", qc->where, qp->id, qc->index);
+
+  return db_build_query_check(qp, count, query);
+}
+
+static char *
 db_build_query_group_albums(struct query_params *qp, struct query_clause *qc)
 {
   char *count;
   char *query;
 
-  count = sqlite3_mprintf("SELECT COUNT(DISTINCT f.songalbumid) FROM files f %s;", qc->where);
+  count = sqlite3_mprintf("SELECT COUNT(DISTINCT f.songalbumid) FROM files f %s %s;", qc->join, qc->where);
   query = sqlite3_mprintf("SELECT" \
 			  " g.id, g.persistentid, f.album, f.album_sort, COUNT(f.id) AS track_count," \
 			  " 1 AS album_count, f.album_artist, f.songartistid," \
 			  " SUM(f.song_length) AS song_length, MIN(f.data_kind) AS data_kind, MIN(f.media_kind) AS media_kind," \
 			  " MAX(f.year) AS year, MAX(f.date_released) AS date_released," \
 			  " MAX(f.time_added) AS time_added, MAX(f.time_played) AS time_played, MAX(f.seek) AS seek " \
-			  "FROM files f JOIN groups g ON f.songalbumid = g.persistentid %s " \
-			  "GROUP BY f.songalbumid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
+			  "FROM files f JOIN groups g ON f.songalbumid = g.persistentid %s %s " \
+			  "GROUP BY f.songalbumid %s %s %s;", qc->join, qc->where, qc->having, qc->order, qc->index);
 
   return db_build_query_check(qp, count, query);
 }
@@ -2339,20 +2452,22 @@ static char *
 db_build_query_browse(struct query_params *qp, struct query_clause *qc)
 {
   const char *where;
+  const char *from;
   const char *select;
   char *count;
   char *query;
 
   select = browse_clause[qp->type & ~Q_F_BROWSE].select;
+  from  = browse_clause[qp->type & ~Q_F_BROWSE].from;
   where  = browse_clause[qp->type & ~Q_F_BROWSE].where;
 
-  count = sqlite3_mprintf("SELECT COUNT(*) FROM (SELECT %s FROM files f %s AND %s != '' %s);", select, qc->where, where, qc->group);
+  count = sqlite3_mprintf("SELECT COUNT(*) FROM (SELECT %s FROM files f %s %s AND %s != '' %s);", select, from, qc->where, where, qc->group);
   query = sqlite3_mprintf("SELECT %s, COUNT(f.id) AS track_count, COUNT(DISTINCT f.songalbumid) AS album_count, COUNT(DISTINCT f.songartistid) AS artist_count,"
 			  " SUM(f.song_length) AS song_length, MIN(f.data_kind) AS data_kind, MIN(f.media_kind) AS media_kind,"
 			  " MAX(f.year) AS year, MAX(f.date_released) AS date_released,"
 			  " MAX(f.time_added) AS time_added, MAX(f.time_played) AS time_played, MAX(f.seek) AS seek "
-			  "FROM files f %s AND %s != '' %s %s %s;",
-			  select, qc->where, where, qc->group, qc->order, qc->index);
+			  "FROM files f %s %s AND %s != '' %s %s %s;",
+			  select, from, qc->where, where, qc->group, qc->order, qc->index);
 
   return db_build_query_check(qp, count, query);
 }
@@ -2402,6 +2517,10 @@ db_query_start(struct query_params *qp)
 
       case Q_PLITEMS:
 	query = db_build_query_plitems(qp, qc);
+	break;
+
+      case Q_FILE_METADATA:
+	query = db_build_query_file_metadata(qp, qc);
 	break;
 
       case Q_GROUP_ALBUMS:
@@ -2573,6 +2692,26 @@ db_query_fetch_file(struct db_media_file_info *dbmfi, struct query_params *qp)
   ret = db_query_fetch(dbmfi, qp, dbmfi_cols_map, ARRAY_SIZE(dbmfi_cols_map));
   if (ret < 0) {
       DPRINTF(E_LOG, L_DB, "Failed to fetch db_media_file_info\n");
+  }
+  return ret;
+}
+
+int
+db_query_fetch_file_metadata(struct db_media_file_metadata_info *dbmfmi, struct query_params *qp)
+{
+  int ret;
+
+  memset(dbmfmi, 0, sizeof(struct db_media_file_metadata_info));
+
+  if (qp->type != Q_FILE_METADATA)
+    {
+      DPRINTF(E_LOG, L_DB, "Not a file metadata query!\n");
+      return -1;
+    }
+
+  ret = db_query_fetch(dbmfmi, qp, dbmfmi_cols_map, ARRAY_SIZE(dbmfmi_cols_map));
+  if (ret < 0) {
+      DPRINTF(E_LOG, L_DB, "Failed to fetch db_media_file_metadata_info\n");
   }
   return ret;
 }
@@ -3596,6 +3735,71 @@ db_file_update_directoryid(const char *path, int dir_id)
   return ((ret < 0) ? -1 : sqlite3_changes(hdl));
 #undef Q_TMPL
 }
+
+/* Files metadata */
+
+int
+db_file_metadata_add(int file_id, int64_t songalbumid, int64_t songartistid, struct media_file_metadata_info *mfmi)
+{
+  int ret = 0;
+
+  if (file_id == 0)
+    {
+      DPRINTF(E_WARN, L_DB, "Trying to add file_metadata with zero file_id\n");
+      return -1;
+    }
+
+  mfmi->file_id = file_id;
+  mfmi->songalbumid = songalbumid;
+  mfmi->songartistid = songartistid;
+
+  ret = bind_mfmi(db_statements.files_metadata_insert, mfmi);
+  if (ret < 0)
+    return -1;
+
+  ret = db_statement_run(db_statements.files_metadata_insert, 0);
+  if (ret < 0)
+    return -1;
+
+  return 0;
+}
+
+int
+db_file_metadata_add_all(int file_id, int64_t songalbumid, int64_t songartistid, struct media_file_metadata_info *mfmi)
+{
+  struct media_file_metadata_info *tmp;
+  int ret = 0;
+
+  tmp = mfmi;
+  while (tmp && ret >= 0)
+    {
+      ret = db_file_metadata_add(file_id, songalbumid, songartistid, tmp);
+      if (ret < 0)
+        {
+          return -1;
+        }
+      tmp = tmp->next;
+    }
+
+  library_update_trigger(LISTENER_DATABASE);
+
+  return 0;
+}
+
+void
+db_file_metadata_clear(int file_id)
+{
+#define Q_TMPL "DELETE FROM files_metadata WHERE file_id = %d;"
+  char *query;
+
+  query = sqlite3_mprintf(Q_TMPL, file_id);
+  db_query_run(query, 1, LISTENER_DATABASE);
+
+#undef Q_TMPL
+}
+
+/* File Metadata */
+
 
 
 /* Playlists */
@@ -7132,9 +7336,12 @@ db_statements_prepare(void)
   db_statements.queue_items_insert = db_statements_prepare_insert(qi_cols_map, ARRAY_SIZE(qi_cols_map), "queue");
   db_statements.queue_items_update = db_statements_prepare_update(qi_cols_map, ARRAY_SIZE(qi_cols_map), "queue");
 
+  db_statements.files_metadata_insert = db_statements_prepare_insert(mfmi_cols_map, ARRAY_SIZE(mfmi_cols_map), "files_metadata");
+
   if ( !db_statements.files_insert || !db_statements.files_update || !db_statements.files_ping
        || !db_statements.playlists_insert || !db_statements.playlists_update
        || !db_statements.queue_items_insert || !db_statements.queue_items_update
+       || !db_statements.files_metadata_insert
      )
     return -1;
 

--- a/src/db.h
+++ b/src/db.h
@@ -32,6 +32,7 @@ enum sort_type {
   S_POS,
   S_SHUFFLE_POS,
   S_DATE_RELEASED,
+  S_MD_VALUE,
 };
 
 #define Q_F_BROWSE (1 << 15)
@@ -46,6 +47,7 @@ enum query_type {
   Q_GROUP_ITEMS      = 7,
   Q_GROUP_DIRS       = 8,
   Q_COUNT_ITEMS      = 9,
+  Q_FILE_METADATA    = 10,
 
   // Keep in sync with browse_clause[]
   Q_BROWSE_ARTISTS   = Q_F_BROWSE | 1,
@@ -57,6 +59,8 @@ enum query_type {
   Q_BROWSE_TRACKS    = Q_F_BROWSE | 7,
   Q_BROWSE_VPATH     = Q_F_BROWSE | 8,
   Q_BROWSE_PATH      = Q_F_BROWSE | 9,
+  Q_BROWSE_GENRES_MD = Q_F_BROWSE | 10,
+  Q_BROWSE_COMPOSERS_MD = Q_F_BROWSE | 11,
 };
 
 #define ARTWORK_UNKNOWN   0
@@ -92,6 +96,7 @@ struct query_params {
   char *having;
   char *order;
   char *group;
+  char *join;
 
   char *filter;
 
@@ -252,6 +257,47 @@ struct media_file_info {
 };
 
 #define mfi_offsetof(field) offsetof(struct media_file_info, field)
+
+/* Keep in sync with metadata_infos */
+enum metadata_kind {
+  MD_LYRICS = 0,
+  MD_GENRE = 1,
+  MD_MUSICBRAINZ_ALBUMID = 2,
+  MD_MUSICBRAINZ_ARTISTID = 3,
+  MD_MUSICBRAINZ_ALBUMARTISTID = 4,
+  MD_COMPOSER = 5,
+};
+
+struct metadata_kind_info {
+  char *label;
+  int is_list;
+};
+
+const struct metadata_kind_info *
+db_metadata_kind_info_get(enum metadata_kind metadata_kind);
+
+struct media_file_metadata_info {
+  uint32_t file_id;
+  int64_t songalbumid;
+  int64_t songartistid;
+  uint32_t idx;
+  enum metadata_kind metadata_kind;
+  char *value;
+  struct media_file_metadata_info *next;
+};
+
+#define mfmi_offsetof(field) offsetof(struct media_file_metadata_info, field)
+
+struct db_media_file_metadata_info {
+  char *file_id;
+  char *songalbumid;
+  char *songartistid;
+  char *idx;
+  char *metadata_kind;
+  char *value;
+};
+
+#define dbmfmi_offsetof(field) offsetof(struct db_media_file_metadata_info, field)
 
 /* Keep in sync with pl_type_label[] */
 /* PL_SPECIAL value must be in sync with type value in Q_PL* in db_init.c */
@@ -589,6 +635,12 @@ void
 free_mfi(struct media_file_info *mfi, int content_only);
 
 void
+free_mfmi(struct media_file_metadata_info *mfmi, int content_only);
+
+void
+free_mfmi_list(struct media_file_metadata_info **mfmi, int content_only);
+
+void
 free_pli(struct playlist_info *pli, int content_only);
 
 void
@@ -635,6 +687,9 @@ db_query_end(struct query_params *qp);
 
 int
 db_query_fetch_file(struct db_media_file_info *dbmfi, struct query_params *qp);
+
+int
+db_query_fetch_file_metadata(struct db_media_file_metadata_info *dbmfmi, struct query_params *qp);
 
 int
 db_query_fetch_pl(struct db_playlist_info *dbpli, struct query_params *qp);
@@ -972,6 +1027,15 @@ db_queue_get_count(uint32_t *nitems);
 
 int
 db_queue_get_pos(uint32_t item_id, char shuffle);
+
+/* Files extra metadata */
+
+int
+db_file_metadata_add(int file_id, int64_t songalbumid, int64_t songartistid, struct media_file_metadata_info *mfmi);
+int
+db_file_metadata_add_all(int file_id, int64_t songalbumid, int64_t songartistid, struct media_file_metadata_info *mfmi);
+void
+db_file_metadata_clear(int file_id);
 
 /* Inotify */
 int

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -208,6 +208,16 @@
   "   channels            INTEGER DEFAULT 0"				\
   ");"
 
+#define T_FILES_METADATA						\
+  "CREATE TABLE IF NOT EXISTS files_metadata ("				\
+  "   file_id            INTEGER NOT NULL,"				\
+  "   songalbumid        INTEGER NOT NULL,"				\
+  "   songartistid       INTEGER NOT NULL,"				\
+  "   metadata_kind      INTEGER NOT NULL,"				\
+  "   idx                INTEGER DEFAULT 0,"				\
+  "   value              TEXT NOT NULL COLLATE DAAP"			\
+  ");"
+
 #define Q_PL1								\
   "INSERT INTO playlists (id, title, type, query, db_timestamp, path, idx, special_id)" \
   " VALUES(1, 'Library', 0, '1 = 1', 0, '', 0, 0);"
@@ -277,6 +287,7 @@ static const struct db_init_query db_init_table_queries[] =
     { T_INOTIFY,   "create table inotify" },
     { T_DIRECTORIES, "create table directories" },
     { T_QUEUE,     "create table queue" },
+    { T_FILES_METADATA, "create table files_metadata" },
 
     { Q_PL1,       "create default playlist" },
     { Q_PL2,       "create default smart playlist 'Music'" },
@@ -378,6 +389,15 @@ static const struct db_init_query db_init_table_queries[] =
 #define I_QUEUE_SHUFFLEPOS				\
   "CREATE INDEX IF NOT EXISTS idx_queue_shufflepos ON queue(shuffle_pos);"
 
+#define I_MD_FILEID_TYPE_IDX				\
+  "CREATE INDEX IF NOT EXISTS idx_filesmd_fileid_type_idx ON files_metadata(file_id, metadata_kind, idx);"
+
+#define I_MD_ALBUMPERSID_TYPE_IDX				\
+  "CREATE INDEX IF NOT EXISTS idx_filesmd_albumid_type_idx ON files_metadata(songalbumid, metadata_kind, idx);"
+
+#define I_MD_ARTISTPERSID_TYPE_IDX				\
+  "CREATE INDEX IF NOT EXISTS idx_filesmd_artistid_type_idx ON files_metadata(songartistid, metadata_kind, idx);"
+
 static const struct db_init_query db_init_index_queries[] =
   {
     { I_RESCAN,    "create rescan index" },
@@ -412,6 +432,8 @@ static const struct db_init_query db_init_index_queries[] =
 
     { I_QUEUE_POS,  "create queue pos index" },
     { I_QUEUE_SHUFFLEPOS,  "create queue shuffle pos index" },
+
+    { I_MD_FILEID_TYPE_IDX,  "create files_metadata file_id type idx index" },
   };
 
 

--- a/src/db_init.h
+++ b/src/db_init.h
@@ -26,7 +26,7 @@
  * is a major upgrade. In other words minor version upgrades permit downgrading
  * the server after the database was upgraded. */
 #define SCHEMA_VERSION_MAJOR 22
-#define SCHEMA_VERSION_MINOR 2
+#define SCHEMA_VERSION_MINOR 3
 
 int
 db_init_indices(sqlite3 *hdl);

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1265,6 +1265,33 @@ static const struct db_upgrade_query db_upgrade_v2202_queries[] =
   };
 
 
+/* ---------------------------- 22.02 -> 22.03 ------------------------------ */
+
+
+#define U_V2203_TABLE_FILES_METADATA					\
+  "CREATE TABLE IF NOT EXISTS files_metadata ("				\
+  "   file_id            INTEGER NOT NULL,"				\
+  "   songalbumid        INTEGER NOT NULL,"				\
+  "   songartistid       INTEGER NOT NULL,"				\
+  "   metadata_kind      INTEGER NOT NULL,"				\
+  "   idx                INTEGER DEFAULT 0,"				\
+  "   value              TEXT NOT NULL COLLATE DAAP"			\
+  ");"
+
+#define U_v2203_SCVER_MAJOR                    \
+  "UPDATE admin SET value = '22' WHERE key = 'schema_version_major';"
+#define U_v2203_SCVER_MINOR                    \
+  "UPDATE admin SET value = '03' WHERE key = 'schema_version_minor';"
+
+static const struct db_upgrade_query db_upgrade_v2203_queries[] =
+  {
+    { U_V2203_TABLE_FILES_METADATA, "create table files_metadata" },
+
+    { U_v2203_SCVER_MAJOR,    "set schema_version_major to 22" },
+    { U_v2203_SCVER_MINOR,    "set schema_version_minor to 03" },
+  };
+
+
 /* -------------------------- Main upgrade handler -------------------------- */
 
 int
@@ -1486,6 +1513,13 @@ db_upgrade(sqlite3 *hdl, int db_ver)
 
     case 2201:
       ret = db_generic_upgrade(hdl, db_upgrade_v2202_queries, ARRAY_SIZE(db_upgrade_v2202_queries));
+      if (ret < 0)
+	return -1;
+
+      /* FALLTHROUGH */
+
+    case 2202:
+      ret = db_generic_upgrade(hdl, db_upgrade_v2203_queries, ARRAY_SIZE(db_upgrade_v2203_queries));
       if (ret < 0)
 	return -1;
 

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -3349,6 +3349,83 @@ jsonapi_reply_library_tracks_put_byid(struct httpd_request *hreq)
 }
 
 static int
+jsonapi_reply_library_track_metadata(struct httpd_request *hreq)
+{
+  const char *track_id;
+  struct query_params query_params = { 0 };
+  struct db_media_file_metadata_info dbmfmi = { 0 };
+  json_object *reply;
+  json_object *list;
+  int id;
+  int intval;
+  const struct metadata_kind_info *metadata_kind_info;
+  int ret = 0;
+
+  if (!is_modified(hreq, DB_ADMIN_DB_UPDATE))
+    return HTTP_NOTMODIFIED;
+
+  track_id = hreq->path_parts[3];
+  if (safe_atoi32(track_id, &id) < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "Error converting track id '%s' to int.\n", track_id);
+      return HTTP_INTERNAL;
+    }
+
+  reply = json_object_new_object();
+
+  query_params.type = Q_FILE_METADATA;
+  query_params.id = id;
+  ret = db_query_start(&query_params);
+  if (ret < 0)
+    goto error;
+
+  while (((ret = db_query_fetch_file_metadata(&dbmfmi, &query_params)) == 0) && (dbmfmi.file_id))
+    {
+      ret = safe_atoi32(dbmfmi.metadata_kind, &intval);
+      if (ret == 0)
+        {
+          metadata_kind_info = db_metadata_kind_info_get(intval);
+          if (metadata_kind_info)
+            {
+              if (metadata_kind_info->is_list)
+                {
+                  list = json_object_object_get(reply, metadata_kind_info->label);
+                  if (!list)
+                    {
+                      list = json_object_new_array();
+                      json_object_object_add(reply, metadata_kind_info->label, list);
+                    }
+                  json_object_array_add(list, json_object_new_string(dbmfmi.value));
+                }
+              else
+                {
+                  json_object_object_add(reply, metadata_kind_info->label, json_object_new_string(dbmfmi.value));
+                }
+            }
+          else
+            DPRINTF(E_LOG, L_WEB, "Error converting metadata kind '%s' to label.\n", dbmfmi.metadata_kind);
+        }
+       else
+        {
+          DPRINTF(E_LOG, L_WEB, "Error converting metadata kind '%s' to int.\n", dbmfmi.metadata_kind);
+        }
+    }
+
+  ret = evbuffer_add_printf(hreq->out_body, "%s", json_object_to_json_string(reply));
+  if (ret < 0)
+    DPRINTF(E_LOG, L_WEB, "browse: Couldn't add track metadata to response buffer.\n");
+
+ error:
+  db_query_end(&query_params);
+  jparse_free(reply);
+
+  if (ret < 0)
+    return HTTP_INTERNAL;
+
+  return HTTP_OK;
+}
+
+static int
 jsonapi_reply_library_track_playlists(struct httpd_request *hreq)
 {
   struct query_params query_params;
@@ -3822,8 +3899,8 @@ jsonapi_reply_library_browse(struct httpd_request *hreq)
     }
   else if (strcmp(browse_type, "composers") == 0)
     {
-      query_params.type = Q_BROWSE_COMPOSERS;
-      query_params.sort = S_COMPOSER;
+      query_params.type = Q_BROWSE_COMPOSERS_MD;
+      query_params.sort = S_MD_VALUE;
       query_params.idx_type = I_NONE;
     }
   else
@@ -3885,16 +3962,16 @@ jsonapi_reply_library_browseitem(struct httpd_request *hreq)
   if (strcmp(browse_type, "genres") == 0)
     {
       query_params.type = Q_BROWSE_GENRES;
-      query_params.sort = S_GENRE;
+      query_params.sort = S_MD_VALUE;
       query_params.idx_type = I_NONE;
-      query_params.filter = db_mprintf("(f.genre = %Q)", item_name);
+      query_params.filter = db_mprintf("(m.value = %Q)", item_name);
     }
   else if (strcmp(browse_type, "composers") == 0)
     {
-      query_params.type = Q_BROWSE_COMPOSERS;
-      query_params.sort = S_COMPOSER;
+      query_params.type = Q_BROWSE_COMPOSERS_MD;
+      query_params.sort = S_MD_VALUE;
       query_params.idx_type = I_NONE;
-      query_params.filter = db_mprintf("(f.composer = %Q)", item_name);
+      query_params.filter = db_mprintf("(m.value = %Q)", item_name);
     }
   else
     {
@@ -3924,6 +4001,77 @@ jsonapi_reply_library_browseitem(struct httpd_request *hreq)
   db_query_end(&query_params);
   jparse_free(reply);
   free_query_params(&query_params, 1);
+
+  if (ret < 0)
+    return HTTP_INTERNAL;
+
+  return HTTP_OK;
+}
+
+static int
+jsonapi_reply_library_browse_albums(struct httpd_request *hreq)
+{
+  struct query_params query_params;
+  const char *browse_type;
+  const char *item_name;
+  json_object *reply;
+  json_object *items;
+  int total;
+  int ret = 0;
+
+  if (!is_modified(hreq, DB_ADMIN_DB_UPDATE))
+    return HTTP_NOTMODIFIED;
+
+  browse_type = hreq->path_parts[2];
+  item_name = hreq->path_parts[3];
+  DPRINTF(E_DBG, L_WEB, "Albums browse item query with type '%s' and item '%s'\n", browse_type, item_name);
+
+  reply = json_object_new_object();
+  items = json_object_new_array();
+  json_object_object_add(reply, "items", items);
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  ret = query_params_limit_set(&query_params, hreq);
+  if (ret < 0)
+    goto error;
+
+  query_params.type = Q_GROUP_ALBUMS;
+  query_params.sort = S_ALBUM;
+
+  if (strcmp(browse_type, "genres") == 0)
+    {
+      query_params.join = db_mprintf("JOIN files_metadata m ON f.id = m.file_id AND m.metadata_kind = %d", MD_GENRE);
+      query_params.filter = db_mprintf("(m.value = %Q)", item_name);
+    }
+  else if (strcmp(browse_type, "composers") == 0)
+    {
+      query_params.join = db_mprintf("JOIN files_metadata m ON f.id = m.file_id AND m.metadata_kind = %d", MD_COMPOSER);
+      query_params.filter = db_mprintf("(m.value = %Q)", item_name);
+    }
+  else
+    {
+      DPRINTF(E_LOG, L_WEB, "Invalid browse type '%s'\n", browse_type);
+      goto error;
+    }
+
+  ret = fetch_albums(&query_params, items, &total);
+  free(query_params.filter);
+  free(query_params.join);
+
+  if (ret < 0)
+    goto error;
+
+  json_object_object_add(reply, "total", json_object_new_int(total));
+  json_object_object_add(reply, "offset", json_object_new_int(query_params.offset));
+  json_object_object_add(reply, "limit", json_object_new_int(query_params.limit));
+
+  ret = evbuffer_add_printf(hreq->out_body, "%s", json_object_to_json_string(reply));
+  if (ret < 0)
+    DPRINTF(E_LOG, L_WEB, "browse: Couldn't add albums to response buffer.\n");
+
+ error:
+  jparse_free(reply);
 
   if (ret < 0)
     return HTTP_INTERNAL;
@@ -4649,7 +4797,9 @@ static struct httpd_uri_map adm_handlers[] =
     { HTTPD_METHOD_GET,    "^/api/library/tracks/[[:digit:]]+$",           jsonapi_reply_library_tracks_get_byid },
     { HTTPD_METHOD_PUT,    "^/api/library/tracks/[[:digit:]]+$",           jsonapi_reply_library_tracks_put_byid },
     { HTTPD_METHOD_GET,    "^/api/library/tracks/[[:digit:]]+/playlists$", jsonapi_reply_library_track_playlists },
+    { HTTPD_METHOD_GET,    "^/api/library/tracks/[[:digit:]]+/metadata$",  jsonapi_reply_library_track_metadata },
     { HTTPD_METHOD_GET,    "^/api/library/(genres|composers)$",            jsonapi_reply_library_browse },
+    { HTTPD_METHOD_GET,    "^/api/library/(genres|composers)/.*/albums$",  jsonapi_reply_library_browse_albums },
     { HTTPD_METHOD_GET,    "^/api/library/(genres|composers)/.*$",         jsonapi_reply_library_browseitem },
     { HTTPD_METHOD_GET,    "^/api/library/count$",                         jsonapi_reply_library_count },
     { HTTPD_METHOD_GET,    "^/api/library/files$",                         jsonapi_reply_library_files },

--- a/src/library.h
+++ b/src/library.h
@@ -138,7 +138,7 @@ struct library_source
  * @return    0 if operation succeeded, -1 on failure.
  */
 int
-library_media_save(struct media_file_info *mfi);
+library_media_save(struct media_file_info *mfi, struct media_file_metadata_info *mfmi);
 
 /*
  * Adds a playlist if pli->id == 0, otherwise updates.

--- a/src/library/filescanner.h
+++ b/src/library/filescanner.h
@@ -8,7 +8,7 @@
 /* --------------------------- Actual scanners ---------------------------- */
 
 int
-scan_metadata_ffmpeg(struct media_file_info *mfi, const char *file);
+scan_metadata_ffmpeg(struct media_file_info *mfi, struct media_file_metadata_info **mfmi, const char *file);
 
 void
 scan_metadata_stream(struct media_file_info *mfi, const char *path);

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -163,7 +163,7 @@ scan_metadata_stream(struct media_file_info *mfi, const char *path)
   mfi->directory_id = DIR_HTTP;
   mfi->scan_kind = SCAN_KIND_FILES;
 
-  ret = scan_metadata_ffmpeg(mfi, path);
+  ret = scan_metadata_ffmpeg(mfi, NULL, path);
   if (ret < 0)
     {
       DPRINTF(E_LOG, L_SCAN, "Playlist URL '%s' is unavailable for probe/metadata, assuming MP3 encoding\n", path);
@@ -275,7 +275,7 @@ process_url(int pl_id, const char *path, struct media_file_info *mfi)
   else
     scan_metadata_stream(mfi, path);
 
-  ret = library_media_save(mfi);
+  ret = library_media_save(mfi, NULL);
   if (ret < 0)
     return -1;
 

--- a/src/library/rssscanner.c
+++ b/src/library/rssscanner.c
@@ -449,7 +449,7 @@ rss_save(struct playlist_info *pli, int *count, enum rss_scan_type scan_type)
 
       mfi_metadata_fixup(&mfi, &ri, feed_title, feed_author, time_added);
 
-      library_media_save(&mfi);
+      library_media_save(&mfi, NULL);
 
       free_mfi(&mfi, 1);
     }

--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -1462,7 +1462,7 @@ track_add(struct spotify_track *track, struct spotify_album *album, const char *
 
       map_track_to_mfi(&mfi, track, album, pl_name);
 
-      library_media_save(&mfi);
+      library_media_save(&mfi, NULL);
 
       free_mfi(&mfi, 1);
     }


### PR DESCRIPTION
This PR are is a poc / rfc.
Its purpose is to revive the discussion about supporting more than one genre/compose for a song #886 and hopefully come to a solution.

It follows what @whatdoineed2do outlined as third option in https://github.com/owntone/owntone-server/issues/886#issuecomment-580348778:

> - add supplementary meta table that can have linkage back to files entry
this is the one I explored most and is still troubling to resolve. If we keep the main files table as it stands, where each cols like genre continue to hold only one item element and any additional elements can be held in the meta table that could be name-value pairs

As described in the comment a new table is introduced `files_metadata` that links to the `files` table and contains key / value pairs. A file can have multiple entries for a key.

When scanning a file with ffmpeg the `files_metadata` table is populated. Genre and composer tags are split by separators (currently hard-coded, should be configurable) and multiple rows are inserted for the file in `files_metadata`.
`files_metadata` entries are not updated, if a file changed, all rows for this `file_id` are deleted and new ones are inserted.
The scan logic for the `files` table is unchanged.

To fetch via the `files_metadata` table, new `query_type`s are added for genre / composer browse queries.
The existing queries and usages to fetch from the DB are unchanged.
 
The JSON API was updated to show how the queries can be used (note, that this currently breaks the web UI).
How the JSON API should be changed in the end, needs further thought (e. g. if it is OK to have breaking changes or not).

In my opinion, this solution has several advantages:

- Support multi-value tags like genre and composer is now possible.
- The new `files_metadata` table allows to easily expose additional metadata fields without impacting existing queries. In this PR for example, I added several MusicBrainz IDs (the web UI could e. g. make use of them to fetch additional data from external service).
- Currently lyrics are stored in the `files` table, which increases the result set size for files queries by a lot (assuming a user that has a lot of files with lyrics tags). Lyrics are only relevant when looking at a single file/song, e. g. in the now playing page or in the file/song details dialog. But most or all of the time a list of songs is fetched, they are not relevant. This might also apply for other tags, and could improve the query execution times for large libraries.
- It can be implemented without breaking the existing APIs.

There are of course some limitations or difficulties with this approach:

- Support for `files_metadata` in smart playlist queries will be difficult and most probably - if possible at all - not performant.
- Genre / composer duplicated in `files` and `files_metadata`. But I would argue here that this is OK. In the `files` table is the raw value from the scan, while in `files_metadata` are the parsed/processed values. And also not normalizing a DB to improve performance is in my opinion also OK.

@ejurgensen, it would be great if you could take a look and say whether this approach is OK and worth fleshing out and looking into in detail.