### PR TITLE
[web] Add missing fields to configuration store

### DIFF
--- a/web-src/src/stores/configuration.js
+++ b/web-src/src/stores/configuration.js
@@ -4,6 +4,8 @@ export const useConfigurationStore = defineStore('ConfigurationStore', {
   state: () => ({
     buildoptions: [],
     version: '',
-    websocket_port: 0
+    websocket_port: 0,
+    allow_modifying_stored_playlists: false,
+    default_playlist_directory: ''
   })
 })


### PR DESCRIPTION
Added the 2 missing config fields to the configurationStore. On v28.11, the absence of these 2 fields was preventing the queue save as playlist button from appearing, even though the /config endpoint was returning the right fields.

Verified by editing the compiled Vue index.js to add these 2 fields: after that the save button appeared in the Queue page.

