### PR TITLE
[logger] Log thread name and id

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,7 +85,15 @@ AC_SEARCH_LIBS([pthread_setname_np], [pthread],
 		[AC_MSG_RESULT([[no]])])],
 	[AC_SEARCH_LIBS([pthread_set_name_np], [pthread],
 		[AC_CHECK_FUNCS([pthread_set_name_np])])])
-
+AC_SEARCH_LIBS([pthread_getname_np], [pthread],
+	[AC_DEFINE([HAVE_PTHREAD_GETNAME_NP], 1,
+		[Define to 1 if you have pthread_getname_np])]
+	[AC_SEARCH_LIBS([pthread_get_name_np], [pthread],
+		[AC_DEFINE([HAVE_PTHREAD_GETNAME_NP], 1,
+			[Define to 1 if you have pthread_get_name_np])])])
+AC_SEARCH_LIBS([pthread_getthreadid_np], [pthread],
+	[AC_DEFINE([HAVE_PTHREAD_GETTHREADID_NP], 1,
+		[Define to 1 if you have pthread_getthreadid_np])])
 AC_SEARCH_LIBS([uuid_generate_random], [uuid],
 	[AC_DEFINE([HAVE_UUID], 1,
 		[Define to 1 if you have uuid_generate_random function])])

--- a/src/db.c
+++ b/src/db.c
@@ -102,6 +102,7 @@ enum fixup_type {
 };
 
 struct db_unlock {
+  char thread_name_tid[32];
   int proceed;
   pthread_cond_t cond;
   pthread_mutex_t lck;
@@ -1446,6 +1447,7 @@ unlock_notify_cb(void **args, int nargs)
     {
       u = (struct db_unlock *)args[i];
 
+      DPRINTF(E_DBG, L_DB, "Notify DB unlock, thread: %s\n", u->thread_name_tid);
       CHECK_ERR(L_DB, pthread_mutex_lock(&u->lck));
 
       u->proceed = 1;
@@ -1460,6 +1462,8 @@ db_wait_unlock(void)
 {
   struct db_unlock u;
   int ret;
+
+  thread_getnametid(u.thread_name_tid, sizeof(u.thread_name_tid));
 
   u.proceed = 0;
   CHECK_ERR(L_DB, mutex_init(&u.lck));
@@ -1477,7 +1481,7 @@ db_wait_unlock(void)
 	}
 
       CHECK_ERR(L_DB, pthread_mutex_unlock(&u.lck));
-    }
+}
 
   CHECK_ERR(L_DB, pthread_cond_destroy(&u.cond));
   CHECK_ERR(L_DB, pthread_mutex_destroy(&u.lck));

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -985,9 +985,7 @@ request_async_cb(void *arg)
 {
   struct httpd_request *hreq = *(struct httpd_request **)arg;
 
-#ifdef HAVE_GETTID
-  DPRINTF(E_DBG, hreq->module->logdomain, "%s request '%s' in worker thread %d\n", hreq->module->name, hreq->uri, (int)gettid());
-#endif
+  DPRINTF(E_DBG, hreq->module->logdomain, "%s request '%s'\n", hreq->module->name, hreq->uri);
 
   // Some handlers require an evbase to schedule events
   hreq->evbase = worker_evbase_get();

--- a/src/logger.c
+++ b/src/logger.c
@@ -136,16 +136,19 @@ static void
 logger_write_with_label(int severity, int domain, const char *content)
 {
   char stamp[32];
+  char thread_nametid[32];
   time_t t;
   struct tm timebuf;
   int ret;
+
+  thread_getnametid(thread_nametid, sizeof(thread_nametid));
 
   t = time(NULL);
   ret = strftime(stamp, sizeof(stamp), "%Y-%m-%d %H:%M:%S", localtime_r(&t, &timebuf));
   if (ret == 0)
     stamp[0] = '\0';
 
-  logger_write("[%s] [%5s] %8s: %s", stamp, severities[severity], labels[domain], content);
+  logger_write("[%s] [%5s] [%-20s] %8s: %s", stamp, severities[severity], thread_nametid, labels[domain], content);
 }
 
 static void

--- a/src/logger.c
+++ b/src/logger.c
@@ -148,7 +148,7 @@ logger_write_with_label(int severity, int domain, const char *content)
   if (ret == 0)
     stamp[0] = '\0';
 
-  logger_write("[%s] [%5s] [%-20s] %8s: %s", stamp, severities[severity], thread_nametid, labels[domain], content);
+  logger_write("[%s] [%5s] [%16s] %8s: %s", stamp, severities[severity], thread_nametid, labels[domain], content);
 }
 
 static void

--- a/src/misc.c
+++ b/src/misc.c
@@ -1820,7 +1820,7 @@ thread_getnametid(char *buf, size_t len)
   pthread_t p = pthread_self();
 
   thread_getname(p, thread_name, sizeof(thread_name));
-  tid = thread_gettid();
+  tid = thread_gettid() % 10000;
   snprintf(buf, len, "%s (%d)", thread_name, tid);
 }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -1788,6 +1788,42 @@ mutex_init(pthread_mutex_t *mutex)
   return err;
 }
 
+int
+thread_gettid()
+{
+  int tid = -1;
+#if defined(HAVE_GETTID)
+  tid = (int)gettid();
+#elif defined(HAVE_PTHREAD_GETTHREADID_NP)
+  tid = pthread_getthreadid_np();
+#endif
+  return tid;
+}
+
+void
+thread_getname(pthread_t thread, char *name, size_t len)
+{
+#if defined(HAVE_PTHREAD_GETNAME_NP)
+  pthread_getname_np(thread, name, len);
+#elif defined(HAVE_PTHREAD_GET_NAME_NP)
+  pthread_get_name_np(thread, name, len);
+#else
+  name[0] = '\0';
+#endif
+}
+
+void
+thread_getnametid(char *buf, size_t len)
+{
+  int tid;
+  char thread_name[32];
+  pthread_t p = pthread_self();
+
+  thread_getname(p, thread_name, sizeof(thread_name));
+  tid = thread_gettid();
+  snprintf(buf, len, "%s (%d)", thread_name, tid);
+}
+
 void
 thread_setname(pthread_t thread, const char *name)
 {

--- a/src/misc.h
+++ b/src/misc.h
@@ -316,6 +316,17 @@ buildopts_get(void);
 int
 mutex_init(pthread_mutex_t *mutex);
 
+// wrapper for gettid/pthread_getthreadid_np
+int
+thread_gettid();
+
+// wrapper for pthread_getname_np/pthread_get_name_np
+void
+thread_getname(pthread_t thread, char *name, size_t len);
+
+void
+thread_getnametid(char *buf, size_t len);
+
 // wrapper for pthread_setname_np/pthread_set_name_np
 void
 thread_setname(pthread_t thread, const char *name);


### PR DESCRIPTION
Given that owntone is multi threaded, adding the info to which thread a log message belongs to, makes it much easier to analyze the logs.

I also find it helpful, to see, which threads are notified in the `unlock_notify_cb`.  

I added logging of the thread name and id unconditionally. It would also be possible to add a command line argument or a compile time/configure flag, to make it conditionally.

Example log with thread name and tid:

```
[2025-02-16 05:37:11] [DEBUG] [owntone (6360)      ]       db: Running query 'PRAGMA synchronous;'
[2025-02-16 05:37:11] [DEBUG] [owntone (6360)      ]       db: Database synchronous: 1
[2025-02-16 05:37:11] [ INFO] [owntone (6334)      ]    cache: Cache thread init
[2025-02-16 05:37:11] [  LOG] [cache (6361)        ]    cache: Could not open '/usr/local/var/cache/owntone/daap.db': unable to open database file
[2025-02-16 05:37:11] [DEBUG] [cache (6361)        ]    cache: Cache closed
[2025-02-16 05:37:11] [  LOG] [cache (6361)        ]    cache: Error: Cache create failed. Cache will be disabled.
[2025-02-16 05:37:11] [DEBUG] [owntone (6362)      ]       db: Running query 'PRAGMA journal_mode=WAL;'
[2025-02-16 05:37:11] [DEBUG] [owntone (6334)      ]       db: Running query 'SELECT value FROM admin a WHERE a.key = 'player_mode_repeat';'
[2025-02-16 05:37:11] [DEBUG] [owntone (6334)      ]       db: No results
[2025-02-16 05:37:11] [DEBUG] [library (6362)      ]       db: Database journal mode: wal
[2025-02-16 05:37:11] [DEBUG] [library (6362)      ]       db: Running query 'PRAGMA synchronous=1;'
[2025-02-16 05:37:11] [DEBUG] [owntone (6334)      ]       db: Running query 'SELECT value FROM admin a WHERE a.key = 'player_mode_shuffle';'
```
