### PR TITLE
Refactor HTTP client session handling; add curl debug logs

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -39,11 +39,12 @@
 #include <event2/keyvalq_struct.h>
 
 #include <curl/curl.h>
+#include <pthread.h>
 
+#include "conffile.h"
 #include "http.h"
 #include "logger.h"
 #include "misc.h"
-#include "conffile.h"
 
 /* Formats we can read so far */
 #define PLAYLIST_UNK 0
@@ -55,17 +56,33 @@
 // Number of seconds the client will wait for a response before aborting
 #define HTTP_CLIENT_TIMEOUT 8
 
+struct http_client_session {
+  CURL *curl;
+  const char *user_agent;
+  long verifypeer;
+  long timeout_sec;
+  pthread_mutex_t mutex;
+};
 
-void
-http_client_session_init(struct http_client_session *session)
+struct http_client_session *
+http_client_session_new(void)
 {
-  session->curl = curl_easy_init();
+  struct http_client_session *session;
+  CHECK_NULL(L_HTTP, session = calloc(1, sizeof(struct http_client_session)));
+  CHECK_NULL(L_HTTP, session->curl = curl_easy_init());
+  session->user_agent = cfg_getstr(cfg_getsec(cfg, "general"), "user_agent");
+  session->verifypeer = cfg_getbool(cfg_getsec(cfg, "general"), "ssl_verifypeer");
+  session->timeout_sec = HTTP_CLIENT_TIMEOUT;
+  pthread_mutex_init(&session->mutex, NULL);
+  return session;
 }
 
 void
-http_client_session_deinit(struct http_client_session *session)
+http_client_session_free(struct http_client_session *session)
 {
   curl_easy_cleanup(session->curl);
+  pthread_mutex_destroy(&session->mutex);
+  free(session);
 }
 
 static void
@@ -108,90 +125,88 @@ curl_request_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 }
 
 int
-http_client_request(struct http_client_ctx *ctx, struct http_client_session *session)
+http_client_request(struct http_client_ctx *ctx, struct http_client_session *client_session)
 {
-  CURL *curl;
+  struct http_client_session *session;
   CURLcode res;
-  struct curl_slist *headers;
+  struct curl_slist *headers = NULL;
   struct onekeyval *okv;
-  const char *user_agent;
-  long verifypeer;
   char header[1024];
   long response_code;
+  int ret;
 
-  if (session)
+  if (!client_session)
     {
-      curl = session->curl;
-      curl_easy_reset(curl);
+      session = http_client_session_new();
     }
   else
     {
-      curl = curl_easy_init();
-    }
-  if (!curl)
-    {
-      DPRINTF(E_LOG, L_HTTP, "Error: Could not get curl handle\n");
-      return -1;
+      session = client_session;
+
+      CHECK_ERR(L_HTTP, pthread_mutex_lock(&session->mutex));
+      curl_easy_reset(session->curl);
     }
 
-  user_agent = cfg_getstr(cfg_getsec(cfg, "general"), "user_agent");
-  curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent);
-  curl_easy_setopt(curl, CURLOPT_URL, ctx->url);
+  curl_easy_setopt(session->curl, CURLOPT_USERAGENT, session->user_agent);
+  curl_easy_setopt(session->curl, CURLOPT_URL, ctx->url);
+  curl_easy_setopt(session->curl, CURLOPT_SSL_VERIFYPEER, session->verifypeer);
 
-  verifypeer = cfg_getbool(cfg_getsec(cfg, "general"), "ssl_verifypeer");
-  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, verifypeer);
-
-  headers = NULL;
   if (ctx->output_headers)
     {
       for (okv = ctx->output_headers->head; okv; okv = okv->next)
 	{
-	  snprintf(header, sizeof(header), "%s: %s", okv->name, okv->value);
+	  ret = snprintf(header, sizeof(header), "%s: %s", okv->name, okv->value);
+	  if (ret < 0 || ret >= sizeof(header))
+	    {
+	      DPRINTF(E_LOG, L_HTTP, "Could not add header, value has more than %zd chars: '%s: %s'\n", sizeof(header),
+	          okv->name, okv->value);
+	      res = CURLE_FAILED_INIT;
+	      goto out;
+	    }
 	  headers = curl_slist_append(headers, header);
         }
 
-      curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+      curl_easy_setopt(session->curl, CURLOPT_HTTPHEADER, headers);
     }
 
-  if (ctx->headers_only)
-    curl_easy_setopt(curl, CURLOPT_NOBODY, 1L); // Makes curl make a HEAD request
-  else if (ctx->output_body)
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, ctx->output_body); // POST request
+  if (ctx->output_body)
+    curl_easy_setopt(session->curl, CURLOPT_POSTFIELDS, ctx->output_body); // POST request
 
-  curl_easy_setopt(curl, CURLOPT_TIMEOUT, HTTP_CLIENT_TIMEOUT);
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_request_cb);
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, ctx);
+  curl_easy_setopt(session->curl, CURLOPT_TIMEOUT, session->timeout_sec);
+  curl_easy_setopt(session->curl, CURLOPT_WRITEFUNCTION, curl_request_cb);
+  curl_easy_setopt(session->curl, CURLOPT_WRITEDATA, ctx);
 
   // Artwork and playlist requests might require redirects
-  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
-  curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5);
+  curl_easy_setopt(session->curl, CURLOPT_FOLLOWLOCATION, 1);
+  curl_easy_setopt(session->curl, CURLOPT_MAXREDIRS, 5);
 
-  /* Make request */
+  // Make request
   DPRINTF(E_INFO, L_HTTP, "Making request for %s\n", ctx->url);
 
-  res = curl_easy_perform(curl);
+  res = curl_easy_perform(session->curl);
+
   if (res != CURLE_OK)
     {
       DPRINTF(E_WARN, L_HTTP, "Request to %s failed: %s\n", ctx->url, curl_easy_strerror(res));
-      curl_slist_free_all(headers);
-      if (!session)
-	{
-	  curl_easy_cleanup(curl);
-	}
-      return -1;
+      goto out;
     }
 
-  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+  curl_easy_getinfo(session->curl, CURLINFO_RESPONSE_CODE, &response_code);
   ctx->response_code = (int) response_code;
-  curl_headers_save(ctx->input_headers, curl);
+  curl_headers_save(ctx->input_headers, session->curl);
 
-  curl_slist_free_all(headers);
-  if (!session)
+out:
+  if (client_session)
     {
-      curl_easy_cleanup(curl);
+      CHECK_ERR(L_HTTP, pthread_mutex_unlock(&session->mutex));
     }
+  else
+    {
+      http_client_session_free(session);
+    }
+  curl_slist_free_all(headers);
 
-  return 0;
+  return res == CURLE_OK ? 0 : -1;
 }
 
 int

--- a/src/http.h
+++ b/src/http.h
@@ -4,15 +4,11 @@
 
 #include <event2/buffer.h>
 #include <event2/http.h>
-#include <curl/curl.h>
 #include "misc.h"
 
 #include <libavformat/avformat.h>
 
-struct http_client_session
-{
-  CURL *curl;
-};
+struct http_client_session;
 
 struct http_client_ctx
 {
@@ -28,12 +24,6 @@ struct http_client_ctx
    */
   struct keyval *input_headers;
   struct evbuffer *input_body;
-
-  /* Cut the connection after the headers have been received
-   * Used for getting Shoutcast/ICY headers for old versions of libav/ffmpeg
-   * (requires libevent 1 or 2.1.4+)
-   */
-  int headers_only;
 
   /* HTTP Response code */
   int response_code;
@@ -56,11 +46,11 @@ struct http_icy_metadata
   uint32_t hash;
 };
 
-void
-http_client_session_init(struct http_client_session *session);
+struct http_client_session *
+http_client_session_new(void);
 
 void
-http_client_session_deinit(struct http_client_session *session);
+http_client_session_free(struct http_client_session *session);
 
 /* Make a http(s) request. We use libcurl to make https requests. We could use
  * libevent and avoid the dependency, but for SSL, libevent needs to be v2.1


### PR DESCRIPTION
First commit contains a small refactoring to make reusing curl handles easier to use (with the `struct http_client_session`). Thread safety is now ensured by `http_client_request(...)` and the implementation details of `struct http_client_session` are now hidden, therefor the include of `<curl.h>` is now gone from `http.h`.

The second commit adds debug / spam logging for libcurl. Info messages, request/response headers are now logged with level DEBUG, request/response body and SSL data are logged with level SPAM.
Seeing the actual requests and responses made by libcurl can be very helpful when analyzing issues. 

Example logs:

```
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl - using HTTP/2
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl - [HTTP/2] [1] OPENED stream for https://accounts.spotify.com/api/token
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl - [HTTP/2] [1] [:method: POST]
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl - [HTTP/2] [1] [:scheme: https]
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl - [HTTP/2] [1] [:authority: accounts.spotify.com]
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl - [HTTP/2] [1] [:path: /api/token]
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl - [HTTP/2] [1] [user-agent: owntone/28.12]
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl - [HTTP/2] [1] [accept: */*]
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl - [HTTP/2] [1] [content-length: 260]
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl - [HTTP/2] [1] [content-type: application/x-www-form-urlencoded]
[2025-02-23 14:06:12] [ SPAM] [  library (1522)]     http: curl > SSL Out
 0000  17 03 03 01 71                                   ....q
[2025-02-23 14:06:12] [ SPAM] [  library (1522)]     http: curl > SSL Out
 0000  17                                               .
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl > Request-Header - POST /api/token HTTP/2
Host: accounts.spotify.com
User-Agent: owntone/28.12
Accept: */*
Content-Length: 260
Content-Type: application/x-www-form-urlencoded

[2025-02-23 14:06:12] [ SPAM] [  library (1522)]     http: curl > Request-Body
 0000  67 72 61 6e 74 5f 74 79 70 65 3d 72 65 66 72 65  grant_type=refre
 0010  73 68 5f 74 6f 6b 65 6e 26 63 6c 69 65 6e 74 5f  sh_token&client_
 ...
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - HTTP/2 200 
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - date: Sun, 23 Feb 2025 13:06:12 GMT
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - content-type: application/json
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - content-length: 409
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - vary: Accept-Encoding
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - x-request-id: 5377fb9e-7ffb-4f00-b6bb-7c0d0112cf19
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - set-cookie: __Host-device_id=AQDmtQhRtDWHhF...;Version=1;Path=/;Max-Age=2147483647;Secure;HttpOnly;SameSite=Lax
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - set-cookie: sp_tr=false;Version=1;Domain=accounts.spotify.com;Path=/;Secure;SameSite=Lax
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - sp-trace-id: 6f67ca213a701110
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - x-envoy-upstream-service-time: 17
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - server: envoy
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - strict-transport-security: max-age=31536000
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - x-content-type-options: nosniff
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - via: HTTP/2 edgeproxy, 1.1 google
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
[2025-02-23 14:06:12] [DEBUG] [  library (1522)]     http: curl < Response-Header - 
[2025-02-23 14:06:12] [ SPAM] [  library (1522)]     http: curl < Response-Body
 0000  7b 22 61 63 63 65 73 73 5f 74 6f 6b 65 6e 22 3a  {"access_token":
 0010  22 42 51 41 58 41 35 71 53 4c 73 55 50 79 5a 78  "BQAXA5qSLsUPyZx
 ...

```