### PR TITLE
[logger] Add support for structured logging ("logfmt" format)

### DIFF
--- a/src/conffile.c
+++ b/src/conffile.c
@@ -49,6 +49,7 @@ static cfg_opt_t sec_general[] =
     CFG_STR("db_backup_path", NULL, CFGF_NONE),
     CFG_STR("logfile", STATEDIR "/log/" PACKAGE ".log", CFGF_NONE),
     CFG_INT_CB("loglevel", E_LOG, CFGF_NONE, &cb_loglevel),
+    CFG_STR("logformat", "default", CFGF_NONE),
     CFG_STR("admin_password", NULL, CFGF_NONE),
     CFG_INT("websocket_port", 3688, CFGF_NONE),
     CFG_STR("websocket_interface", NULL, CFGF_NONE),

--- a/src/logger.h
+++ b/src/logger.h
@@ -84,7 +84,7 @@ void
 logger_detach(void);
 
 int
-logger_init(char *file, char *domains, int severity);
+logger_init(char *file, char *domains, int severity, char *logformat);
 
 void
 logger_deinit(void);

--- a/src/main.c
+++ b/src/main.c
@@ -495,6 +495,7 @@ main(int argc, char **argv)
   int loglevel = -1;
   char *logdomains = NULL;
   char *logfile = NULL;
+  char *logformat = NULL;
   char *ffid = NULL;
   char *pidfile = PIDFILE;
   char *webroot = WEB_ROOT;
@@ -510,26 +511,26 @@ main(int argc, char **argv)
   int i;
   int ret;
 
-  struct option option_map[] =
-    {
-      { "ffid",         1, NULL, 'b' },
-      { "debug",        1, NULL, 'd' },
-      { "logdomains",   1, NULL, 'D' },
-      { "foreground",   0, NULL, 'f' },
-      { "config",       1, NULL, 'c' },
-      { "pidfile",      1, NULL, 'P' },
-      { "version",      0, NULL, 'v' },
-      { "webroot",      1, NULL, 'w' },
-      { "sqliteext",    1, NULL, 's' },
-      { "testrun",      0, NULL, 't' }, // Used for CI, not documented to user
+  struct option option_map[] = {
+    { "ffid",          1, NULL, 'b' },
+    { "debug",         1, NULL, 'd' },
+    { "logdomains",    1, NULL, 'D' },
+    { "foreground",    0, NULL, 'f' },
+    { "config",        1, NULL, 'c' },
+    { "pidfile",       1, NULL, 'P' },
+    { "version",       0, NULL, 'v' },
+    { "webroot",       1, NULL, 'w' },
+    { "sqliteext",     1, NULL, 's' },
+    { "testrun",       0, NULL, 't' }, // Used for CI, not documented to user
 
-      { "mdns-no-rsp",  0, NULL, 512 },
-      { "mdns-no-daap", 0, NULL, 513 },
-      { "mdns-no-cname",0, NULL, 514 },
-      { "mdns-no-web",  0, NULL, 515 },
+    { "mdns-no-rsp",   0, NULL, 512 },
+    { "mdns-no-daap",  0, NULL, 513 },
+    { "mdns-no-cname", 0, NULL, 514 },
+    { "mdns-no-web",   0, NULL, 515 },
+    { "logformat",     1, NULL, 516 },
 
-      { NULL,           0, NULL, 0 }
-    };
+    { NULL,            0, NULL, 0   }
+  };
 
   while ((option = getopt_long(argc, argv, "D:d:c:P:ftb:vw:s:", option_map, NULL)) != -1)
     {
@@ -549,6 +550,10 @@ main(int argc, char **argv)
 
 	  case 515:
 	    mdns_no_web = true;
+	    break;
+
+	  case 516:
+	    logformat = optarg;
 	    break;
 
 	  case 't':
@@ -603,7 +608,7 @@ main(int argc, char **argv)
 	}
     }
 
-  ret = logger_init(NULL, NULL, (loglevel < 0) ? E_LOG : loglevel);
+  ret = logger_init(NULL, NULL, (loglevel < 0) ? E_LOG : loglevel, NULL);
   if (ret != 0)
     {
       fprintf(stderr, "Could not initialize log facility\n");
@@ -625,10 +630,11 @@ main(int argc, char **argv)
   /* Reinit log facility with configfile values */
   if (loglevel < 0)
     loglevel = cfg_getint(cfg_getsec(cfg, "general"), "loglevel");
-
+  if (!logformat)
+    logformat = cfg_getstr(cfg_getsec(cfg, "general"), "logformat");
   logfile = cfg_getstr(cfg_getsec(cfg, "general"), "logfile");
 
-  ret = logger_init(logfile, logdomains, loglevel);
+  ret = logger_init(logfile, logdomains, loglevel, logformat);
   if (ret != 0)
     {
       fprintf(stderr, "Could not reinitialize log facility with config file settings\n");


### PR DESCRIPTION
Especially with debug or spam logging enabled, it is difficult to spot warnings or errors in the log file. It would be nice, if owntone would support structured logging get the most out of existing logging tools out of the box.

With this PR, I propose to add support for the [logfmt](https://brandur.org/logfmt) log format. 
In my opinion, logfmt has a good balance between being human and machine readable. And a lot of tools have support for it. I like for example [hl](https://github.com/pamburus/hl), a terminal log viewer with formatting and filtering.

Example log:

```
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="OwnTone version 28.12 taking off "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="Built with: "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="- ffmpeg "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="- Spotify "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="- librespot-c "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="- LastFM "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="- Without Chromecast "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="- MPD "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="- Websockets "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="- ALSA "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="- Webinterface "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="- Regex "
time=2025-02-23T16:29:48+0100 level=INFO thread="owntone (6128)" component=main msg="Initialized with ffmpeg 6.1.1-3ubuntu5 "
time=2025-02-23T16:29:48+0100 level=DEBUG thread="owntone (6128)" component=main msg="Initialized with gcrypt 1.10.3 "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=main msg="mDNS init "
time=2025-02-23T16:29:48+0100 level=DEBUG thread="owntone (6128)" component=mdns msg="Initializing Avahi mDNS "
time=2025-02-23T16:29:48+0100 level=LOG thread="owntone (6128)" component=mdns msg="Avahi state change: Client running "
time=2025-02-23T16:29:48+0100 level=DEBUG thread="owntone (6128)" component=mdns msg="No entries yet... skipping service create "
time=2025-02-23T16:29:48+0100 level=INFO thread="owntone (6128)" component=main msg="Initializing database "
```

Opening the log with hl:

```
hl owntone.log

# Only show info logs and above
hl owntone.log --level info

# Only show logs for "scan" component
hl owntone.log --filter component=scan
```

![image](https://github.com/user-attachments/assets/ff666630-ddc6-404b-a0da-65ae19a93a6a)

