### PR TITLE
[gha] Run CI for all pushes, not just to `master`

### DIFF
--- a/.github/workflows/build_htdocs.yml
+++ b/.github/workflows/build_htdocs.yml
@@ -2,8 +2,6 @@ name: Build htdocs
 
 on:
   push:
-    branches:
-      - master
     paths:
       - 'web-src/**'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,8 +2,6 @@ name: "CodeQL"
 
 on:
   push:
-    branches:
-      - master
     paths-ignore:
       - 'docs/**'
       - 'htdocs/**'

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -2,8 +2,6 @@ name: FreeBSD
 
 on:
   push:
-    branches:
-      - master
     paths-ignore:
       - 'docs/**'
       - 'htdocs/**'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,8 +1,7 @@
 name: build and deploy mkdocs to github pages
 on:
   push:
-    branches:
-      - master
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -14,3 +13,4 @@ jobs:
       - run: pip install mkdocs-material
       - run: pip install mkdocs-minify-plugin
       - run: mkdocs gh-deploy --force
+        if: github.ref_name == github.event.repository.default_branch

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,8 +2,6 @@ name: macOS
 
 on:
   push:
-    branches:
-      - master
     paths-ignore:
       - 'docs/**'
       - 'htdocs/**'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,8 +2,6 @@ name: Ubuntu
 
 on:
   push:
-    branches:
-      - master
     paths-ignore:
       - 'docs/**'
       - 'htdocs/**'

--- a/.github/workflows/webui_lint.yml
+++ b/.github/workflows/webui_lint.yml
@@ -2,8 +2,6 @@ name: Web UI Lint
 
 on:
   push:
-    branches:
-      - master
     paths:
       - 'web-src/**'
   pull_request:


### PR DESCRIPTION
This will allow contributors to run CI in their forks and notice problems even before creating a pull request.
GitHub pages are still only deployed when pushing to `master`.

CC @ejurgensen 
