### PR TITLE
[gha] Fix MacOS workflows failing with undefined macro errors mk2

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,6 +58,7 @@ jobs:
       # We configure a non-privileged setup, since how to add a "owntone" system
       # user in macOS isn't clear to me (useradd etc. isn't available)
       run: |
+        export ACLOCAL_PATH="$(brew --prefix)/share/gettext/m4:$ACLOCAL_PATH"
         export CFLAGS="-I$(brew --prefix)/include -I$(brew --prefix sqlite)/include"
         export LDFLAGS="-L$(brew --prefix)/lib -L$(brew --prefix sqlite)/lib"
         autoreconf -fi


### PR DESCRIPTION
The macros shipped with Homebrew's gettext are no longer installed to $(brew --prefix)/share/aclocal, so aclocal can't find them, resulting in autoreconf failing.

Fixes issue #1889