### PR TITLE
[gha] Run all push-enabled CI weekly, not just `codeql-analysis.yml`

### DIFF
--- a/.github/workflows/build_htdocs.yml
+++ b/.github/workflows/build_htdocs.yml
@@ -6,6 +6,8 @@ on:
       - master
     paths:
       - 'web-src/**'
+  schedule:
+    - cron: '0 19 * * 6'
 
 jobs:
   build:

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -15,6 +15,8 @@ on:
       - 'docs/**'
       - 'htdocs/**'
       - 'web-src/**'
+  schedule:
+    - cron: '0 19 * * 6'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: '0 19 * * 6'
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,6 +15,8 @@ on:
       - 'docs/**'
       - 'htdocs/**'
       - 'web-src/**'
+  schedule:
+    - cron: '0 19 * * 6'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/webui_lint.yml
+++ b/.github/workflows/webui_lint.yml
@@ -11,6 +11,8 @@ on:
       - master
     paths:
       - 'web-src/**'
+  schedule:
+    - cron: '0 19 * * 6'
 
 jobs:
   check:


### PR DESCRIPTION
Follow-up to my comment https://github.com/owntone/owntone-server/issues/1888#issuecomment-2887749569 .

This will make GitHub Actions detect and alert about breakage no later than one week after breakage occurred -- the kind of breakage that originates from the ground moving below out feet, e.g. changes in the GitHub Actions images being used.

This is the last pull request that I have in the pipeline. No further pull requests planned.

CC @ejurgensen 