### PR TITLE
Update dns-sd arguments for modern Apple Music app

### DIFF
--- a/docs/advanced/remote-access.md
+++ b/docs/advanced/remote-access.md
@@ -8,7 +8,7 @@ need to broadcast the DAAP service to iTunes on your local machine. On macOS the
 command is:
 
 ```shell
-dns-sd -P iTunesServer _daap._tcp local 3689 localhost.local 127.0.0.1 "ffid=12345"
+dns-sd -P iTunesServer _daap._tcp local 3689 localhost.local 127.0.0.1 "txtvers=1" "ffid=12345678" "Database ID=0123456789abcdef" "Machine ID=0123456789abcdef" "Machine Name=owntone" "mtd-version=28.10" "iTSh Version=131073" "Version=196610"
 ```
 
 The `ffid` key is required but its value does not matter.


### PR DESCRIPTION
Just having the `"ffid=..."` argument doesn't seem to be enough to make the owntone library appear in recent versions of Apple's Music.app; I copied the extra arguments from a real instance of Music.app and with them, the owntone library is usable in Music.app like it used to work in iTunes.