### PR TITLE
[web] Fix modal hight to display buttons on mobile

### DIFF
--- a/web-src/src/components/ModalDialog.vue
+++ b/web-src/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ export default {
 
 <style scoped>
 .card-content {
-  max-height: calc(100vh - calc(4 * var(--bulma-navbar-height)));
+  max-height: calc(100vh - var(--bulma-modal-content-spacing-tablet) - calc(4 * var(--bulma-navbar-height)));
   overflow: auto;
 }
 .fade-leave-active {


### PR DESCRIPTION
On mobile the modal dialogs for albums do not show the action buttons (play, add, ...) any more.

It seems, that Bulma calculates the height of the `modal-content` differently then it did before. Because of that, the value for `max-height` of `card-content` in `ModalDialog.vue` is too high. On mobile viewport this leads to the `content-footer` being rendered outside of `modal-content`.

The `max-height` of `modal-content` is `calc(100vh - var(--bulma-modal-content-spacing-tablet))` on tablet viewport. Subtracting the previous value from it, makes the action buttons visible on mobile again.

Not sure if there is a more elegant approach ...