### PR TITLE
make AirPlay start buffer configurable

### DIFF
--- a/owntone.conf.in
+++ b/owntone.conf.in
@@ -336,6 +336,12 @@ audio {
 	# Switch Airplay 1 streams to uncompressed ALAC (as opposed to regular,
 	# compressed ALAC). Reduces CPU use at the cost of network bandwidth.
 #	uncompressed_alac = false
+
+	# Adjust the initial session buffer size.
+	# The default 2000ms is conservative. With modern networks, it's often
+	# possible to reduce this to 250ms, which most listeners will perceive as
+	# starting "instantly" without sacrificing playback reliability.
+	# start_buffer_ms = 2000
 #}
 
 # AirPlay per device settings

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -36,6 +36,7 @@
 #include "logger.h"
 #include "misc.h"
 #include "conffile.h"
+#include "outputs.h"
 
 
 /* Forward */
@@ -165,6 +166,7 @@ static cfg_opt_t sec_airplay_shared[] =
   {
     CFG_INT("control_port", 0, CFGF_NONE),
     CFG_INT("timing_port", 0, CFGF_NONE),
+    CFG_INT("start_buffer_ms", OUTPUTS_BUFFER_DURATION*1000, CFGF_NONE),
     CFG_BOOL("uncompressed_alac", cfg_false, CFGF_NONE),
     CFG_END()
   };


### PR DESCRIPTION
Make the initial AirPlay start buffer configurable to allow "instant" streaming on networks/hardware that support it.

The default value for `start_buffer_ms` is 2000ms, preserving existing behavior. Values near 250ms work in some setups providing a much more responsive streaming experience.

```
airplay_shared {
  start_buffer_ms = 250
}
```