### PR TITLE
Allow each AirPlay device to have an offset to manually adjust audio sync

### DIFF
--- a/owntone.conf.in
+++ b/owntone.conf.in
@@ -367,6 +367,14 @@ audio {
 
 	# Name used in the speaker list, overrides name from the device
 #	nickname = "My speaker name"
+
+  # offset_ms adjusts this device to improve multi-room sync when a device has
+	# an intrinsic delay, like a DSP or lagging implementation of HDMI.
+  # Negative values correspond to moving local audio ahead, positive correspond
+	# to delaying it. The unit is milliseconds. The offset must be between -1000
+	# and 1000 (+/- 1 sec).
+# offset_ms = 0
+
 #}
 
 # Chromecast settings

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -179,6 +179,7 @@ static cfg_opt_t sec_airplay[] =
     CFG_STR("password", NULL, CFGF_NONE),
     CFG_BOOL("raop_disable", cfg_false, CFGF_NONE),
     CFG_STR("nickname", NULL, CFGF_NONE),
+    CFG_INT("offset_ms", 0, CFGF_NONE),
     CFG_END()
   };
 


### PR DESCRIPTION
The main use case is when an Airport Express or AppleTV is connected to an external amplifier that introduces some lag that is noticeable in a multi-room setup.

Certain stereo receivers have a lag caused by either the interface (SPDIF or HDMI) or certain types of room correction signal processing. Typically this is 10-20ms.

The `offset_ms` config variable matches the way it is documented to work for Chromecast devices.
