### PR TITLE
[outputs] Allow more responsive streaming with configurable output buffer

### DIFF
--- a/owntone.conf.in
+++ b/owntone.conf.in
@@ -67,6 +67,12 @@ general {
 	# unusual platform and experience audio drop-outs, you can try changing
 	# this option
 #	high_resolution_clock = yes
+
+	# Milliseconds the audio outputs should buffer before starting playback.
+	# The default is 2000 ms, because some Airplay devices are hardcoded to
+	# use this. You may be able to reduce this to 250 ms, which most
+	# listeners will perceive as starting "instantly".
+#	start_buffer_ms = 2000
 }
 
 # Library configuration
@@ -205,7 +211,7 @@ library {
 #	force_decode = { "format", "format" }
 	# Prefer transcode to wav (default), alac or mpeg (mp3 with the bit rate
 	# configured below in the streaming section). Note that alac requires
-	# precomputing and caching mp4 headers, which takes both cpu and disk. 
+	# precomputing and caching mp4 headers, which takes both cpu and disk.
 #	prefer_format = "format"
 
 	# Set ffmpeg filters (similar to 'ffmpeg -af xxx') that you want the
@@ -418,7 +424,7 @@ spotify {
 	# list
 #	exclude = false
 
-	# A Roku/SoundBridge can power up in 2 modes: (default) reconnect to the 
+	# A Roku/SoundBridge can power up in 2 modes: (default) reconnect to the
 	# previously used library (ie OwnTone) or in a 'cleared library' mode.
 	# The Roku power up behaviour is affected by how OwnTone disconnects
 	# from the Roku device.

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -76,6 +76,7 @@ static cfg_opt_t sec_general[] =
     CFG_STR("user_agent", PACKAGE_NAME "/" PACKAGE_VERSION, CFGF_NONE),
     CFG_BOOL("ssl_verifypeer", cfg_true, CFGF_NONE),
     CFG_BOOL("timer_test", cfg_false, CFGF_NONE),
+    CFG_INT("start_buffer_ms", 2000, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -1620,6 +1620,21 @@ timespec_add(struct timespec time1, struct timespec time2)
   return result;
 }
 
+struct timespec
+timespec_sub(struct timespec time1, struct timespec time2)
+{
+  struct timespec result;
+
+  result.tv_sec = time1.tv_sec - time2.tv_sec;
+  result.tv_nsec = time1.tv_nsec - time2.tv_nsec;
+  if (result.tv_nsec < 0)
+    {
+      result.tv_sec--;
+      result.tv_nsec += 1000000000L;
+    }
+  return result;
+}
+
 int
 timespec_cmp(struct timespec time1, struct timespec time2)
 {

--- a/src/misc.h
+++ b/src/misc.h
@@ -265,6 +265,9 @@ clock_gettime_with_res(clockid_t clock_id, struct timespec *tp, struct timespec 
 struct timespec
 timespec_add(struct timespec time1, struct timespec time2);
 
+struct timespec
+timespec_sub(struct timespec time1, struct timespec time2);
+
 int
 timespec_cmp(struct timespec time1, struct timespec time2);
 

--- a/src/outputs.h
+++ b/src/outputs.h
@@ -35,12 +35,6 @@
 // as one.
 #define OUTPUTS_MAX_QUALITY_SUBSCRIPTIONS 5
 
-// Number of seconds the outputs should buffer before starting playback. Note
-// this value cannot freely be changed because 1) some Airplay devices ignore
-// the values we give and stick to 2 seconds, 2) those devices that can handle
-// different values can only do so within a limited range (maybe max 3 secs)
-#define OUTPUTS_BUFFER_DURATION 2
-
 // Whether the device should be *displayed* as selected is not given by
 // device->selected, since that means "has the user selected the device",
 // without taking into account whether it is working or available. This macro
@@ -275,6 +269,9 @@ struct output_definition
 
 struct output_device *
 outputs_device_get(uint64_t device_id);
+
+uint64_t
+outputs_buffer_duration_ms_get(void);
 
 /* ----------------------- Called by backend modules ------------------------ */
 

--- a/src/outputs/airplay.c
+++ b/src/outputs/airplay.c
@@ -202,7 +202,7 @@ struct airplay_extra
 struct airplay_master_session
 {
   struct evbuffer *input_buffer;
-  int input_buffer_samples;
+  uint32_t input_buffer_samples;
 
   // ALAC encoder and buffer for encoded data
   struct encode_ctx *encode_ctx;
@@ -214,14 +214,14 @@ struct airplay_master_session
 
   uint8_t *rawbuf;
   size_t rawbuf_size;
-  int samples_per_packet;
+  uint32_t samples_per_packet;
 
   struct media_quality quality;
 
   // Number of samples that we tell the output to buffer (this will mean that
   // the position that we send in the sync packages are offset by this amount
   // compared to the rtptimes of the corresponding RTP packages we are sending)
-  int output_buffer_samples;
+  uint32_t output_buffer_samples;
 
   struct airplay_master_session *next;
 };
@@ -1168,7 +1168,7 @@ master_session_make(struct media_quality *quality)
   rms->quality = *quality;
   rms->samples_per_packet = AIRPLAY_SAMPLES_PER_PACKET;
   rms->rawbuf_size = STOB(rms->samples_per_packet, quality->bits_per_sample, quality->channels);
-  rms->output_buffer_samples = OUTPUTS_BUFFER_DURATION * quality->sample_rate;
+  rms->output_buffer_samples = outputs_buffer_duration_ms_get() * quality->sample_rate / 1000;
 
   CHECK_NULL(L_AIRPLAY, rms->rawbuf = malloc(rms->rawbuf_size));
   CHECK_NULL(L_AIRPLAY, rms->input_buffer = evbuffer_new());

--- a/src/outputs/cast.c
+++ b/src/outputs/cast.c
@@ -1948,7 +1948,7 @@ cast_session_make(struct output_device *device, int family, int callback_id)
       offset_ms = 0;
     }
 
-  offset_ms += OUTPUTS_BUFFER_DURATION * 1000 + CAST_DEVICE_START_DELAY_MS;
+  offset_ms += outputs_buffer_duration_ms_get() + CAST_DEVICE_START_DELAY_MS;
 
   cs->offset_ts.tv_sec  = (offset_ms / 1000);
   cs->offset_ts.tv_nsec = (offset_ms % 1000) * 1000000UL;

--- a/src/outputs/fifo.c
+++ b/src/outputs/fifo.c
@@ -393,6 +393,8 @@ fifo_write(struct output_buffer *obuf)
   struct fifo_session *fifo_session = sessions;
   struct fifo_packet *packet;
   struct timespec now;
+  struct timespec delay;
+  uint64_t buffer_duration_ms;
   ssize_t bytes;
   int i;
 
@@ -430,8 +432,12 @@ fifo_write(struct output_buffer *obuf)
   if (!buffer.tail)
     buffer.tail = packet;
 
-  now.tv_sec = obuf->pts.tv_sec - OUTPUTS_BUFFER_DURATION;
-  now.tv_nsec = obuf->pts.tv_sec;
+  buffer_duration_ms = outputs_buffer_duration_ms_get();
+
+  delay.tv_sec = buffer_duration_ms / 1000;
+  delay.tv_nsec = (buffer_duration_ms % 1000) * 1000000UL;
+
+  now = timespec_sub(obuf->pts, delay);
 
   while (buffer.tail && (timespec_cmp(buffer.tail->pts, now) == -1))
     {

--- a/src/outputs/pulse.c
+++ b/src/outputs/pulse.c
@@ -570,6 +570,7 @@ stream_open(struct pulse_session *ps, struct media_quality *quality, pa_stream_n
   pa_stream_flags_t flags;
   pa_sample_spec ss;
   pa_cvolume cvol;
+  uint64_t buffer_duration_ms;
   int offset_ms;
   int ret;
 
@@ -602,8 +603,9 @@ stream_open(struct pulse_session *ps, struct media_quality *quality, pa_stream_n
   pa_stream_set_state_callback(ps->stream, cb, ps);
 
   flags = PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_AUTO_TIMING_UPDATE;
+  buffer_duration_ms = outputs_buffer_duration_ms_get();
 
-  ps->attr.tlength   = STOB((OUTPUTS_BUFFER_DURATION * 1000 + offset_ms) * ss.rate / 1000, quality->bits_per_sample, quality->channels);
+  ps->attr.tlength   = STOB((buffer_duration_ms + offset_ms) * ss.rate / 1000, quality->bits_per_sample, quality->channels);
   ps->attr.maxlength = 2 * ps->attr.tlength;
   ps->attr.prebuf    = (uint32_t)-1;
   ps->attr.minreq    = (uint32_t)-1;

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -156,7 +156,7 @@ struct raop_extra
 struct raop_master_session
 {
   struct evbuffer *input_buffer;
-  int input_buffer_samples;
+  uint32_t input_buffer_samples;
 
   struct rtp_session *rtp_session;
 
@@ -168,7 +168,7 @@ struct raop_master_session
 
   uint8_t *rawbuf;
   size_t rawbuf_size;
-  int samples_per_packet;
+  uint32_t samples_per_packet;
   bool encrypt;
 
   struct media_quality quality;
@@ -176,7 +176,7 @@ struct raop_master_session
   // Number of samples that we tell the output to buffer (this will mean that
   // the position that we send in the sync packages are offset by this amount
   // compared to the rtptimes of the corresponding RTP packages we are sending)
-  int output_buffer_samples;
+  uint32_t output_buffer_samples;
 
   struct raop_master_session *next;
 };
@@ -1906,7 +1906,7 @@ master_session_make(struct media_quality *quality, bool encrypt)
   rms->quality = *quality;
   rms->samples_per_packet = RAOP_SAMPLES_PER_PACKET;
   rms->rawbuf_size = STOB(rms->samples_per_packet, quality->bits_per_sample, quality->channels);
-  rms->output_buffer_samples = OUTPUTS_BUFFER_DURATION * quality->sample_rate;
+  rms->output_buffer_samples = outputs_buffer_duration_ms_get() * quality->sample_rate / 1000;
 
   CHECK_NULL(L_RAOP, rms->rawbuf = malloc(rms->rawbuf_size));
   CHECK_NULL(L_RAOP, rms->input_buffer = evbuffer_new());

--- a/src/player.c
+++ b/src/player.c
@@ -222,7 +222,7 @@ struct player_source
   uint64_t read_end;
 
   // Same as the above, but added with samples equivalent to
-  // OUTPUTS_BUFFER_DURATION. So when the session position reaches play_start it
+  // outputs_buffer_duration_ms. When the session position reaches play_start it
   // means the media should actually be playing on your device.
   uint64_t play_start;
   uint64_t play_end;
@@ -256,7 +256,7 @@ struct player_session
   struct timespec start_ts;
 
   // The time the first sample in the buffer should be played by the output,
-  // without taking output buffer time (OUTPUTS_BUFFER_DURATION) into account.
+  // without taking outputs_buffer_duration_ms into account.
   // It will be equal to:
   // pts = start_ts + ticks_elapsed * player_tick_interval
   struct timespec pts;
@@ -898,7 +898,7 @@ session_update_read_quality(struct media_quality *quality)
   pb_session.reading_now->quality = *quality;
 
   samples_per_read = ((uint64_t)quality->sample_rate * (player_tick_interval.tv_nsec / 1000000)) / 1000;
-  pb_session.reading_now->output_buffer_samples = OUTPUTS_BUFFER_DURATION * quality->sample_rate;
+  pb_session.reading_now->output_buffer_samples = outputs_buffer_duration_ms_get() * quality->sample_rate / 1000;
 
   pb_session.bufsize = STOB(samples_per_read, quality->bits_per_sample, quality->channels);
   pb_session.read_deficit_max = STOB(((uint64_t)quality->sample_rate * PLAYER_READ_BEHIND_MAX) / 1000, quality->bits_per_sample, quality->channels);
@@ -1050,7 +1050,7 @@ event_read_metadata(struct input_metadata *metadata)
   DPRINTF(E_DBG, L_PLAYER, "event_read_metadata()\n");
 
   // Add the metadata to the register of pending events with a trigger position
-  // that corresponds to OUTPUTS_BUFFER_DURATION into the future. If we have
+  // that corresponds to outputs_buffer_duration_ms into the future. If we have
   // received a negative position we assume the metadata needs to be delayed
   // until the position is 0.
   if (metadata->pos_is_updated && metadata->pos_ms < 0)


### PR DESCRIPTION
This allows the user to configure the outputs buffering time. It's a modified version of PR #1954 by @msolo:

Make the initial start buffer configurable to allow "instant" streaming on networks/hardware that support it.

The default value for start_buffer_ms is 2000ms, preserving existing behavior. Values near 250ms work in some setups providing a much more responsive streaming experience.