### PR TITLE
Add per-speaker AirPlay protocol selection via API

### DIFF
--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -340,6 +340,9 @@ GET /api/outputs
 | has_password    | boolean  | `true` if output is password protected |
 | requires_auth   | boolean  | `true` if output requires authentication |
 | needs_auth_key  | boolean  | `true` if output requires an authorization key (device verification) |
+| supports_raop   | boolean  | `true` if the output supports AirPlay 1 / RAOP |
+| supports_airplay2 | boolean| `true` if the output supports AirPlay 2 |
+| protocol        | string   | Selected protocol: `default`, `raop` or `airplay2` |
 | volume          | integer  | Volume in percent (0 - 100)               |
 | offset_ms       | integer  | User configured playback offset in ms (positive value means delay) |
 | format          | string   | Stream format                             |
@@ -488,6 +491,7 @@ PUT /api/outputs/{id}
 | --------------- | --------- | ----------------------------------------------------------------------------- |
 | selected        | boolean   | *(Optional)* `true` to enable and `false` to disable the output               |
 | volume          | integer   | *(Optional)* Volume in percent (0 - 100)                                      |
+| protocol        | string    | *(Optional)* Protocol selection: `default`, `raop` or `airplay2`             |
 | pin             | string    | *(Optional)* PIN for device verification                                      |
 | format          | string    | *(Optional)* Stream format                                                    |
 | offset_ms       | integer   | *(Optional)* Playback offset in ms (-2000 - 2000, positive value means delay) |

--- a/src/db.c
+++ b/src/db.c
@@ -4793,10 +4793,15 @@ db_admin_delete(const char *key)
 int
 db_speaker_save(struct output_device *device)
 {
-#define Q_TMPL "INSERT OR REPLACE INTO speakers (id, selected, volume, name, auth_key, format, offset_ms) VALUES (%" PRIi64 ", %d, %d, %Q, %Q, %d, %d);"
+#define Q_TMPL "INSERT OR REPLACE INTO speakers (id, selected, volume, name, auth_key, auth_key_raop, auth_key_airplay2, format, offset_ms, protocol) VALUES (%" PRIi64 ", %d, %d, %Q, %Q, %Q, %Q, %d, %d, %d);"
+  const char *auth_key_raop;
+  const char *auth_key_airplay2;
   char *query;
 
-  query = sqlite3_mprintf(Q_TMPL, device->id, device->selected, device->volume, device->name, device->auth_key, device->selected_format, device->offset_ms);
+  auth_key_raop = device->supports_raop ? ((device->active_type == OUTPUT_TYPE_RAOP) ? device->auth_key : device->raop.auth_key) : device->auth_key_raop;
+  auth_key_airplay2 = device->supports_airplay2 ? ((device->active_type == OUTPUT_TYPE_AIRPLAY) ? device->auth_key : device->airplay2.auth_key) : device->auth_key_airplay2;
+
+  query = sqlite3_mprintf(Q_TMPL, device->id, device->selected, device->volume, device->name, device->auth_key, auth_key_raop, auth_key_airplay2, device->selected_format, device->offset_ms, device->protocol_preference);
 
   return db_query_run(query, 1, 0);
 #undef Q_TMPL
@@ -4805,9 +4810,10 @@ db_speaker_save(struct output_device *device)
 int
 db_speaker_get(struct output_device *device, uint64_t id)
 {
-#define Q_TMPL "SELECT s.selected, s.volume, s.name, s.auth_key, s.format, s.offset_ms FROM speakers s WHERE s.id = %" PRIi64 ";"
+#define Q_TMPL "SELECT s.selected, s.volume, s.name, s.auth_key, s.auth_key_raop, s.auth_key_airplay2, s.format, s.offset_ms, s.protocol FROM speakers s WHERE s.id = %" PRIi64 ";"
   sqlite3_stmt *stmt;
   char *query;
+  char *legacy_auth_key = NULL;
   int ret;
 
   query = sqlite3_mprintf(Q_TMPL, id);
@@ -4844,11 +4850,28 @@ db_speaker_get(struct output_device *device, uint64_t id)
   free(device->name);
   device->name = safe_strdup((char *)sqlite3_column_text(stmt, 2));
 
-  free(device->auth_key);
-  device->auth_key = safe_strdup((char *)sqlite3_column_text(stmt, 3));
+  legacy_auth_key = safe_strdup((char *)sqlite3_column_text(stmt, 3));
 
-  device->selected_format = sqlite3_column_int(stmt, 4);
-  device->offset_ms = sqlite3_column_int(stmt, 5);
+  free(device->auth_key_raop);
+  device->auth_key_raop = safe_strdup((char *)sqlite3_column_text(stmt, 4));
+
+  free(device->auth_key_airplay2);
+  device->auth_key_airplay2 = safe_strdup((char *)sqlite3_column_text(stmt, 5));
+
+  if (legacy_auth_key)
+    {
+      if (!device->auth_key_raop)
+	device->auth_key_raop = safe_strdup(legacy_auth_key);
+      if (!device->auth_key_airplay2)
+	device->auth_key_airplay2 = safe_strdup(legacy_auth_key);
+    }
+
+  free(device->auth_key);
+  device->auth_key = NULL;
+
+  device->selected_format = sqlite3_column_int(stmt, 6);
+  device->offset_ms = sqlite3_column_int(stmt, 7);
+  device->protocol_preference = sqlite3_column_int(stmt, 8);
 
 #ifdef DB_PROFILE
   while (db_blocking_step(stmt) == SQLITE_ROW)
@@ -4856,6 +4879,7 @@ db_speaker_get(struct output_device *device, uint64_t id)
 #endif
 
   sqlite3_finalize(stmt);
+  free(legacy_auth_key);
 
   ret = 0;
 

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -153,8 +153,11 @@
   "   volume         INTEGER NOT NULL,"			\
   "   name           VARCHAR(255) DEFAULT NULL,"       \
   "   auth_key       VARCHAR(2048) DEFAULT NULL,"      \
+  "   auth_key_raop  VARCHAR(2048) DEFAULT NULL,"      \
+  "   auth_key_airplay2 VARCHAR(2048) DEFAULT NULL,"   \
   "   format         INTEGER DEFAULT 0,"                \
-  "   offset_ms      INTEGER DEFAULT 0"			\
+  "   offset_ms      INTEGER DEFAULT 0,"		\
+  "   protocol       INTEGER DEFAULT 0"		\
   ");"
 
 #define T_INOTIFY					\
@@ -549,4 +552,3 @@ db_init_tables(sqlite3 *hdl)
 
   return ret;
 }
-

--- a/src/db_init.h
+++ b/src/db_init.h
@@ -26,7 +26,7 @@
  * is a major upgrade. In other words minor version upgrades permit downgrading
  * the server after the database was upgraded. */
 #define SCHEMA_VERSION_MAJOR 22
-#define SCHEMA_VERSION_MINOR 3
+#define SCHEMA_VERSION_MINOR 4
 
 int
 db_init_indices(sqlite3 *hdl);

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1284,6 +1284,33 @@ static const struct db_upgrade_query db_upgrade_v2203_queries[] =
   };
 
 
+/* ---------------------------- 22.03 -> 22.04 ------------------------------ */
+
+#define U_v2204_ALTER_SPEAKERS_ADD_AUTH_KEY_RAOP \
+  "ALTER TABLE speakers ADD COLUMN auth_key_raop VARCHAR(2048) DEFAULT NULL;"
+
+#define U_v2204_ALTER_SPEAKERS_ADD_AUTH_KEY_AIRPLAY2 \
+  "ALTER TABLE speakers ADD COLUMN auth_key_airplay2 VARCHAR(2048) DEFAULT NULL;"
+
+#define U_v2204_ALTER_SPEAKERS_ADD_PROTOCOL \
+  "ALTER TABLE speakers ADD COLUMN protocol INTEGER DEFAULT 0;"
+
+#define U_v2204_SCVER_MAJOR                    \
+  "UPDATE admin SET value = '22' WHERE key = 'schema_version_major';"
+#define U_v2204_SCVER_MINOR                    \
+  "UPDATE admin SET value = '04' WHERE key = 'schema_version_minor';"
+
+static const struct db_upgrade_query db_upgrade_v2204_queries[] =
+  {
+    { U_v2204_ALTER_SPEAKERS_ADD_AUTH_KEY_RAOP, "alter table speakers add column auth_key_raop" },
+    { U_v2204_ALTER_SPEAKERS_ADD_AUTH_KEY_AIRPLAY2, "alter table speakers add column auth_key_airplay2" },
+    { U_v2204_ALTER_SPEAKERS_ADD_PROTOCOL, "alter table speakers add column protocol" },
+
+    { U_v2204_SCVER_MAJOR,    "set schema_version_major to 22" },
+    { U_v2204_SCVER_MINOR,    "set schema_version_minor to 04" },
+  };
+
+
 /* -------------------------- Main upgrade handler -------------------------- */
 
 int
@@ -1512,6 +1539,13 @@ db_upgrade(sqlite3 *hdl, int db_ver)
 
     case 2202:
       ret = db_generic_upgrade(hdl, db_upgrade_v2203_queries, ARRAY_SIZE(db_upgrade_v2203_queries));
+      if (ret < 0)
+	return -1;
+
+      /* FALLTHROUGH */
+
+    case 2203:
+      ret = db_generic_upgrade(hdl, db_upgrade_v2204_queries, ARRAY_SIZE(db_upgrade_v2204_queries));
       if (ret < 0)
 	return -1;
 

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1632,6 +1632,9 @@ speaker_to_json(struct player_speaker_info *spk)
   json_object_object_add(output, "has_password", json_object_new_boolean(spk->has_password));
   json_object_object_add(output, "requires_auth", json_object_new_boolean(spk->requires_auth));
   json_object_object_add(output, "needs_auth_key", json_object_new_boolean(spk->needs_auth_key));
+  json_object_object_add(output, "supports_raop", json_object_new_boolean(spk->supports_raop));
+  json_object_object_add(output, "supports_airplay2", json_object_new_boolean(spk->supports_airplay2));
+  json_object_object_add(output, "protocol", json_object_new_string(spk->protocol));
   json_object_object_add(output, "volume", json_object_new_int(spk->absvol));
   json_object_object_add(output, "offset_ms", json_object_new_int(spk->offset_ms));
   json_object_object_add(output, "format", json_object_new_string(media_format_to_string(spk->format)));
@@ -1699,8 +1702,10 @@ jsonapi_reply_outputs_put_byid(struct httpd_request *hreq)
   bool selected;
   int volume;
   int offset_ms;
+  enum output_protocol_preference protocol;
   const char *pin;
   const char *format;
+  const char *protocol_str;
   int ret;
 
   ret = safe_atou64(hreq->path_parts[2], &output_id);
@@ -1715,6 +1720,18 @@ jsonapi_reply_outputs_put_byid(struct httpd_request *hreq)
     {
       DPRINTF(E_LOG, L_WEB, "Failed to parse incoming request\n");
       goto error;
+    }
+
+  if (jparse_contains_key(request, "protocol", json_type_string))
+    {
+      protocol_str = jparse_str_from_obj(request, "protocol");
+      protocol = outputs_protocol_from_string(protocol_str);
+      if (protocol < 0)
+	goto error;
+
+      ret = player_speaker_protocol_set(output_id, protocol);
+      if (ret < 0)
+	goto error;
     }
 
   if (jparse_contains_key(request, "selected", json_type_boolean))

--- a/src/libairptp/src/airptp.c
+++ b/src/libairptp/src/airptp.c
@@ -150,6 +150,9 @@ airptp_daemon_start(struct airptp_handle *hdl, uint64_t clock_id_seed, bool is_s
 {
   int ret;
 
+  if (!hdl)
+    RETURN_ERROR(AIRPTP_ERR_INVALID, "Can't start daemon, handle is NULL");
+
   if (!hdl->is_daemon || hdl->state != AIRPTP_STATE_PORTS_BOUND)
     RETURN_ERROR(AIRPTP_ERR_INVALID, "Can't start daemon, ports not bound not in daemon mode");
 

--- a/src/outputs.c
+++ b/src/outputs.c
@@ -831,15 +831,15 @@ outputs_device_get(uint64_t device_id)
 }
 
 struct output_device *
-outputs_device_get_for_type(uint64_t device_id, enum output_types type)
+outputs_device_get_bound(uint64_t device_id, enum output_types type)
 {
   struct output_device *device;
-
-  (void)type;
 
   device = outputs_device_get(device_id);
   if (!device)
     return NULL;
+
+  outputs_device_bind(device, type);
 
   return device;
 }
@@ -851,6 +851,38 @@ outputs_device_bind(struct output_device *device, enum output_types type)
     return;
 
   device_variant_bind(device, type);
+}
+
+void
+outputs_device_requires_auth_set(struct output_device *device, bool requires_auth)
+{
+  struct output_device_variant *variant;
+
+  device->requires_auth = requires_auth;
+  if (!device_has_protocol_variants(device))
+    return;
+
+  variant = device_variant_get(device, device->active_type);
+  if (!variant)
+    return;
+
+  variant->requires_auth = requires_auth;
+}
+
+void
+outputs_device_v6_disabled_set(struct output_device *device, bool v6_disabled)
+{
+  struct output_device_variant *variant;
+
+  device->v6_disabled = v6_disabled;
+  if (!device_has_protocol_variants(device))
+    return;
+
+  variant = device_variant_get(device, device->active_type);
+  if (!variant)
+    return;
+
+  variant->v6_disabled = v6_disabled;
 }
 
 void

--- a/src/outputs.c
+++ b/src/outputs.c
@@ -189,6 +189,12 @@ device_variant_sync(struct output_device *device, enum output_types type)
   if (!variant)
     return;
 
+  DPRINTF(E_SPAM, L_PLAYER,
+	  "Variant sync for device '%s' (%" PRIu64 "): sync_type=%d live(type=%d active=%d session=%p extra=%p v4=%p:%d v6=%p:%d) variant(before session=%p extra=%p v4=%p:%d v6=%p:%d)\n",
+	  device->name, device->id, type, device->type, device->active_type, device->session, device->extra_device_info,
+	  device->v4_address, device->v4_port, device->v6_address, device->v6_port,
+	  variant->session, variant->extra_device_info, variant->v4_address, variant->v4_port, variant->v6_address, variant->v6_port);
+
   variant->requires_auth = device->requires_auth;
   variant->v6_disabled = device->v6_disabled;
   variant->auth_key = device->auth_key;
@@ -203,6 +209,11 @@ device_variant_sync(struct output_device *device, enum output_types type)
   device->extra_device_info = NULL;
   variant->session = device->session;
   device->session = NULL;
+
+  DPRINTF(E_SPAM, L_PLAYER,
+	  "Variant sync done for device '%s' (%" PRIu64 "): sync_type=%d live(after session=%p extra=%p) variant(after session=%p extra=%p v4=%p:%d v6=%p:%d)\n",
+	  device->name, device->id, type, device->session, device->extra_device_info,
+	  variant->session, variant->extra_device_info, variant->v4_address, variant->v4_port, variant->v6_address, variant->v6_port);
 }
 
 static void
@@ -218,12 +229,64 @@ device_variant_bind(struct output_device *device, enum output_types type)
     }
 
   bound_type = device->type;
-  if (bound_type == OUTPUT_TYPE_RAOP || bound_type == OUTPUT_TYPE_AIRPLAY)
-    device_variant_sync(device, bound_type);
+  DPRINTF(E_SPAM, L_PLAYER,
+	  "Variant bind begin for device '%s' (%" PRIu64 "): bound_type=%d target_type=%d active=%d live(session=%p extra=%p) raop(session=%p extra=%p) airplay2(session=%p extra=%p)\n",
+	  device->name, device->id, bound_type, type, device->active_type, device->session, device->extra_device_info,
+	  device->raop.session, device->raop.extra_device_info, device->airplay2.session, device->airplay2.extra_device_info);
 
   variant = device_variant_get(device, type);
   if (!variant)
     return;
+
+  if (bound_type == type)
+    {
+      device->active_type = type;
+      device->type_name = airplay_type_name;
+      device->requires_auth = variant->requires_auth;
+      device->v6_disabled = variant->v6_disabled;
+
+      if (!device->auth_key && variant->auth_key)
+	{
+	  device->auth_key = variant->auth_key;
+	  variant->auth_key = NULL;
+	}
+
+      if (!device->v4_address && variant->v4_address)
+	{
+	  device->v4_address = variant->v4_address;
+	  variant->v4_address = NULL;
+	  device->v4_port = variant->v4_port;
+	}
+
+      if (!device->v6_address && variant->v6_address)
+	{
+	  device->v6_address = variant->v6_address;
+	  variant->v6_address = NULL;
+	  device->v6_port = variant->v6_port;
+	}
+
+      if (!device->extra_device_info && variant->extra_device_info)
+	{
+	  device->extra_device_info = variant->extra_device_info;
+	  variant->extra_device_info = NULL;
+	}
+
+      if (!device->session && variant->session)
+	{
+	  device->session = variant->session;
+	  variant->session = NULL;
+	}
+
+      DPRINTF(E_SPAM, L_PLAYER,
+	      "Variant bind restored for device '%s' (%" PRIu64 "): already bound to type=%d live(session=%p extra=%p v4=%p:%d v6=%p:%d) variant(session=%p extra=%p)\n",
+	      device->name, device->id, type, device->session, device->extra_device_info,
+	      device->v4_address, device->v4_port, device->v6_address, device->v6_port,
+	      variant->session, variant->extra_device_info);
+      return;
+    }
+
+  if (bound_type == OUTPUT_TYPE_RAOP || bound_type == OUTPUT_TYPE_AIRPLAY)
+    device_variant_sync(device, bound_type);
 
   device->type = type;
   device->active_type = type;
@@ -242,6 +305,12 @@ device_variant_bind(struct output_device *device, enum output_types type)
   variant->extra_device_info = NULL;
   device->session = variant->session;
   variant->session = NULL;
+
+  DPRINTF(E_SPAM, L_PLAYER,
+	  "Variant bind done for device '%s' (%" PRIu64 "): target_type=%d active=%d live(session=%p extra=%p v4=%p:%d v6=%p:%d) raop(session=%p extra=%p) airplay2(session=%p extra=%p)\n",
+	  device->name, device->id, type, device->active_type, device->session, device->extra_device_info,
+	  device->v4_address, device->v4_port, device->v6_address, device->v6_port,
+	  device->raop.session, device->raop.extra_device_info, device->airplay2.session, device->airplay2.extra_device_info);
 }
 
 static void
@@ -839,6 +908,11 @@ outputs_device_session_remove(uint64_t device_id)
   device = outputs_device_get(device_id);
   if (device)
     {
+      DPRINTF(E_SPAM, L_PLAYER,
+	      "Session remove for device '%s' (%" PRIu64 "): type=%d active=%d live_session=%p raop_session=%p airplay2_session=%p live_extra=%p raop_extra=%p airplay2_extra=%p\n",
+	      device->name, device->id, device->type, device->active_type, device->session,
+	      device->raop.session, device->airplay2.session,
+	      device->extra_device_info, device->raop.extra_device_info, device->airplay2.extra_device_info);
       if (device_has_protocol_variants(device))
 	{
 	  variant = device_variant_get(device, device->active_type);
@@ -847,6 +921,11 @@ outputs_device_session_remove(uint64_t device_id)
 	}
 
       device->session = NULL;
+
+      DPRINTF(E_SPAM, L_PLAYER,
+	      "Session remove done for device '%s' (%" PRIu64 "): type=%d active=%d live_session=%p raop_session=%p airplay2_session=%p\n",
+	      device->name, device->id, device->type, device->active_type, device->session,
+	      device->raop.session, device->airplay2.session);
     }
 
   return;
@@ -973,6 +1052,7 @@ outputs_device_add(struct output_device *add, bool new_deselect)
   char *keep_name;
   int keep_offset_ms;
   struct output_device_variant *variant;
+  void *keep_extra_device_info;
   int ret;
 
   for (device = outputs_device_list; device; device = device->next)
@@ -1040,6 +1120,11 @@ outputs_device_add(struct output_device *add, bool new_deselect)
       if (add->type == OUTPUT_TYPE_RAOP || add->type == OUTPUT_TYPE_AIRPLAY)
 	{
 	  variant = device_variant_get(device, add->type);
+	  DPRINTF(E_SPAM, L_PLAYER,
+		  "Device update for '%s' (%" PRIu64 "): add_type=%d bound_type=%d active=%d live(extra=%p session=%p) raop(extra=%p session=%p) airplay2(extra=%p session=%p) add(extra=%p)\n",
+		  device->name, device->id, add->type, device->type, device->active_type, device->extra_device_info, device->session,
+		  device->raop.extra_device_info, device->raop.session, device->airplay2.extra_device_info, device->airplay2.session,
+		  add->extra_device_info);
 	  variant->available = true;
 	  variant->advertised = true;
 	  variant->requires_auth = add->requires_auth;
@@ -1071,13 +1156,18 @@ outputs_device_add(struct output_device *add, bool new_deselect)
 
 	  if (variant->extra_device_info && outputs[add->type]->device_free_extra)
 	    {
+	      keep_extra_device_info = device->extra_device_info;
 	      device->extra_device_info = variant->extra_device_info;
 	      variant->extra_device_info = NULL;
 	      outputs[add->type]->device_free_extra(device);
-	      device->extra_device_info = NULL;
+	      device->extra_device_info = keep_extra_device_info;
 	    }
 	  variant->extra_device_info = add->extra_device_info;
 	  add->extra_device_info = NULL;
+	  DPRINTF(E_SPAM, L_PLAYER,
+		  "Device update stored variant for '%s' (%" PRIu64 "): add_type=%d live(extra=%p session=%p) raop(extra=%p session=%p) airplay2(extra=%p session=%p)\n",
+		  device->name, device->id, add->type, device->extra_device_info, device->session,
+		  device->raop.extra_device_info, device->raop.session, device->airplay2.extra_device_info, device->airplay2.session);
 	}
       else
 	{
@@ -1205,6 +1295,11 @@ outputs_device_start(struct output_device *device, output_status_cb cb, bool onl
   int ret;
 
   type = device_type_effective(device);
+  DPRINTF(E_SPAM, L_PLAYER,
+	  "Device start request for '%s' (%" PRIu64 "): only_probe=%d effective_type=%d bound_type=%d active=%d supports(raop=%d airplay2=%d) live(extra=%p session=%p) raop(extra=%p session=%p) airplay2(extra=%p session=%p)\n",
+	  device->name, device->id, only_probe, type, device->type, device->active_type, device->supports_raop, device->supports_airplay2,
+	  device->extra_device_info, device->session,
+	  device->raop.extra_device_info, device->raop.session, device->airplay2.extra_device_info, device->airplay2.session);
   if (device_has_protocol_variants(device))
     device_variant_bind(device, type);
 
@@ -1229,6 +1324,10 @@ outputs_device_stop(struct output_device *device, output_status_cb cb)
   int ret;
 
   type = device_type_effective(device);
+  DPRINTF(E_SPAM, L_PLAYER,
+	  "Device stop request for '%s' (%" PRIu64 "): effective_type=%d bound_type=%d active=%d live(extra=%p session=%p) raop(extra=%p session=%p) airplay2(extra=%p session=%p)\n",
+	  device->name, device->id, type, device->type, device->active_type, device->extra_device_info, device->session,
+	  device->raop.extra_device_info, device->raop.session, device->airplay2.extra_device_info, device->airplay2.session);
   if (device_has_protocol_variants(device))
     device_variant_bind(device, type);
 

--- a/src/outputs.c
+++ b/src/outputs.c
@@ -118,6 +118,149 @@ static int outputs_master_volume;
 static uint64_t outputs_buffer_duration_ms;
 
 static bool outputs_exclusive_mode;
+static const char *airplay_type_name = "AirPlay";
+
+
+static bool
+device_has_protocol_variants(struct output_device *device)
+{
+  return device && (device->supports_raop || device->supports_airplay2);
+}
+
+static struct output_device_variant *
+device_variant_get(struct output_device *device, enum output_types type)
+{
+  if (type == OUTPUT_TYPE_RAOP)
+    return &device->raop;
+  if (type == OUTPUT_TYPE_AIRPLAY)
+    return &device->airplay2;
+
+  return NULL;
+}
+
+static enum output_types
+device_type_default_resolve(struct output_device *device)
+{
+  if (!device_has_protocol_variants(device))
+    return device->type;
+
+  if (device->protocol_preference == OUTPUT_PROTOCOL_RAOP && device->supports_raop)
+    return OUTPUT_TYPE_RAOP;
+
+  if (device->protocol_preference == OUTPUT_PROTOCOL_AIRPLAY2 && device->supports_airplay2)
+    return OUTPUT_TYPE_AIRPLAY;
+
+#ifdef PREFER_AIRPLAY2
+  if (device->supports_airplay2)
+    return OUTPUT_TYPE_AIRPLAY;
+  if (device->supports_raop)
+    return OUTPUT_TYPE_RAOP;
+#else
+  if (device->supports_raop)
+    return OUTPUT_TYPE_RAOP;
+  if (device->supports_airplay2)
+    return OUTPUT_TYPE_AIRPLAY;
+#endif
+
+  return device->type;
+}
+
+static enum output_types
+device_type_effective(struct output_device *device)
+{
+  if (!device_has_protocol_variants(device))
+    return device->type;
+
+  if (device->session && (device->active_type == OUTPUT_TYPE_RAOP || device->active_type == OUTPUT_TYPE_AIRPLAY))
+    return device->active_type;
+
+  return device_type_default_resolve(device);
+}
+
+static void
+device_variant_sync(struct output_device *device, enum output_types type)
+{
+  struct output_device_variant *variant;
+
+  if (!device_has_protocol_variants(device))
+    return;
+
+  variant = device_variant_get(device, type);
+  if (!variant)
+    return;
+
+  variant->requires_auth = device->requires_auth;
+  variant->v6_disabled = device->v6_disabled;
+  variant->auth_key = device->auth_key;
+  device->auth_key = NULL;
+  variant->v4_address = device->v4_address;
+  device->v4_address = NULL;
+  variant->v6_address = device->v6_address;
+  device->v6_address = NULL;
+  variant->v4_port = device->v4_port;
+  variant->v6_port = device->v6_port;
+  variant->extra_device_info = device->extra_device_info;
+  device->extra_device_info = NULL;
+  variant->session = device->session;
+  device->session = NULL;
+}
+
+static void
+device_variant_bind(struct output_device *device, enum output_types type)
+{
+  struct output_device_variant *variant;
+  enum output_types bound_type;
+
+  if (!device_has_protocol_variants(device))
+    {
+      device->active_type = device->type;
+      return;
+    }
+
+  bound_type = device->type;
+  if (bound_type == OUTPUT_TYPE_RAOP || bound_type == OUTPUT_TYPE_AIRPLAY)
+    device_variant_sync(device, bound_type);
+
+  variant = device_variant_get(device, type);
+  if (!variant)
+    return;
+
+  device->type = type;
+  device->active_type = type;
+  device->type_name = airplay_type_name;
+  device->requires_auth = variant->requires_auth;
+  device->v6_disabled = variant->v6_disabled;
+  device->auth_key = variant->auth_key;
+  variant->auth_key = NULL;
+  device->v4_address = variant->v4_address;
+  variant->v4_address = NULL;
+  device->v6_address = variant->v6_address;
+  variant->v6_address = NULL;
+  device->v4_port = variant->v4_port;
+  device->v6_port = variant->v6_port;
+  device->extra_device_info = variant->extra_device_info;
+  variant->extra_device_info = NULL;
+  device->session = variant->session;
+  variant->session = NULL;
+}
+
+static void
+device_state_refresh(struct output_device *device)
+{
+  bool has_variant_session;
+
+  if (!device_has_protocol_variants(device))
+    return;
+
+  device->advertised = device->raop.advertised || device->airplay2.advertised;
+  device->supports_raop = device->raop.available;
+  device->supports_airplay2 = device->airplay2.available;
+  has_variant_session = (device->raop.session != NULL || device->airplay2.session != NULL);
+  if (!device->session && !has_variant_session)
+    device->active_type = device_type_default_resolve(device);
+
+  device_variant_bind(device, device_type_effective(device));
+}
 
 static struct outputs_callback_register outputs_cb_register[OUTPUTS_MAX_CALLBACKS];
 static struct event *outputs_deferredev;
@@ -618,6 +761,38 @@ outputs_device_get(uint64_t device_id)
   return NULL;
 }
 
+struct output_device *
+outputs_device_get_for_type(uint64_t device_id, enum output_types type)
+{
+  struct output_device *device;
+
+  (void)type;
+
+  device = outputs_device_get(device_id);
+  if (!device)
+    return NULL;
+
+  return device;
+}
+
+void
+outputs_device_bind(struct output_device *device, enum output_types type)
+{
+  if (!device_has_protocol_variants(device))
+    return;
+
+  device_variant_bind(device, type);
+}
+
+void
+outputs_device_refresh(struct output_device *device)
+{
+  if (!device_has_protocol_variants(device))
+    return;
+
+  device_state_refresh(device);
+}
+
 uint64_t
 outputs_buffer_duration_ms_get(void)
 {
@@ -638,10 +813,18 @@ int
 outputs_device_session_add(uint64_t device_id, void *session)
 {
   struct output_device *device;
+  struct output_device_variant *variant;
 
   device = outputs_device_get(device_id);
   if (!device)
     return -1;
+
+  if (device_has_protocol_variants(device))
+    {
+      variant = device_variant_get(device, device->active_type);
+      if (variant)
+	variant->session = session;
+    }
 
   device->session = session;
   return 0;
@@ -651,10 +834,20 @@ void
 outputs_device_session_remove(uint64_t device_id)
 {
   struct output_device *device;
+  struct output_device_variant *variant;
 
   device = outputs_device_get(device_id);
   if (device)
-    device->session = NULL;
+    {
+      if (device_has_protocol_variants(device))
+	{
+	  variant = device_variant_get(device, device->active_type);
+	  if (variant)
+	    variant->session = NULL;
+	}
+
+      device->session = NULL;
+    }
 
   return;
 }
@@ -779,27 +972,13 @@ outputs_device_add(struct output_device *add, bool new_deselect)
   struct output_device *device;
   char *keep_name;
   int keep_offset_ms;
+  struct output_device_variant *variant;
   int ret;
 
   for (device = outputs_device_list; device; device = device->next)
     {
       if (device->id == add->id)
 	break;
-    }
-
-  // This is relevant for Airplay 1 and 2 where the same device can support both
-  if (device && device->type != add->type)
-    {
-      if (outputs_priority(device) < outputs_priority(add))
-	{
-	  DPRINTF(E_DBG, L_PLAYER, "Ignoring type %s for device '%s', will use type %s\n", add->type_name, add->name, device->type_name);
-	  outputs_device_free(add);
-	  return NULL;
-	}
-
-      // Remove existing device, higher priority device will be added below
-      outputs_device_remove(device);
-      device = NULL;
     }
 
   // New device
@@ -828,32 +1007,95 @@ outputs_device_add(struct output_device *add, bool new_deselect)
       if (new_deselect)
 	device->selected = 0;
 
+      device->active_type = device->type;
+      if (device->type == OUTPUT_TYPE_RAOP)
+	{
+	  device->supports_raop = 1;
+	  device->raop.available = true;
+	  device->raop.advertised = true;
+	  device->raop.requires_auth = device->requires_auth;
+	  device->raop.v6_disabled = device->v6_disabled;
+	  device->raop.auth_key = device->auth_key_raop;
+	  device->auth_key_raop = NULL;
+	  device_variant_bind(device, OUTPUT_TYPE_RAOP);
+	}
+      else if (device->type == OUTPUT_TYPE_AIRPLAY)
+	{
+	  device->supports_airplay2 = 1;
+	  device->airplay2.available = true;
+	  device->airplay2.advertised = true;
+	  device->airplay2.requires_auth = device->requires_auth;
+	  device->airplay2.v6_disabled = device->v6_disabled;
+	  device->airplay2.auth_key = device->auth_key_airplay2;
+	  device->auth_key_airplay2 = NULL;
+	  device_variant_bind(device, OUTPUT_TYPE_AIRPLAY);
+	}
+
       device->next = outputs_device_list;
       outputs_device_list = device;
     }
   // Update to a device already in the list
   else
     {
-      if (add->v4_address)
+      if (add->type == OUTPUT_TYPE_RAOP || add->type == OUTPUT_TYPE_AIRPLAY)
 	{
-	  free(device->v4_address);
+	  variant = device_variant_get(device, add->type);
+	  variant->available = true;
+	  variant->advertised = true;
+	  variant->requires_auth = add->requires_auth;
+	  variant->v6_disabled = add->v6_disabled;
 
-	  device->v4_address = add->v4_address;
-	  device->v4_port = add->v4_port;
+	  if (!variant->auth_key)
+	    {
+	      if (add->type == OUTPUT_TYPE_RAOP && device->auth_key_raop)
+		variant->auth_key = safe_strdup(device->auth_key_raop);
+	      else if (add->type == OUTPUT_TYPE_AIRPLAY && device->auth_key_airplay2)
+		variant->auth_key = safe_strdup(device->auth_key_airplay2);
+	    }
 
-	  // Address is ours now
-	  add->v4_address = NULL;
+	  if (add->v4_address)
+	    {
+	      free(variant->v4_address);
+	      variant->v4_address = add->v4_address;
+	      variant->v4_port = add->v4_port;
+	      add->v4_address = NULL;
+	    }
+
+	  if (add->v6_address)
+	    {
+	      free(variant->v6_address);
+	      variant->v6_address = add->v6_address;
+	      variant->v6_port = add->v6_port;
+	      add->v6_address = NULL;
+	    }
+
+	  if (variant->extra_device_info && outputs[add->type]->device_free_extra)
+	    {
+	      device->extra_device_info = variant->extra_device_info;
+	      variant->extra_device_info = NULL;
+	      outputs[add->type]->device_free_extra(device);
+	      device->extra_device_info = NULL;
+	    }
+	  variant->extra_device_info = add->extra_device_info;
+	  add->extra_device_info = NULL;
 	}
-
-      if (add->v6_address)
+      else
 	{
-	  free(device->v6_address);
+	  if (add->v4_address)
+	    {
+	      free(device->v4_address);
+	      device->v4_address = add->v4_address;
+	      device->v4_port = add->v4_port;
+	      add->v4_address = NULL;
+	    }
 
-	  device->v6_address = add->v6_address;
-	  device->v6_port = add->v6_port;
-
-	  // Address is ours now
-	  add->v6_address = NULL;
+	  if (add->v6_address)
+	    {
+	      free(device->v6_address);
+	      device->v6_address = add->v6_address;
+	      device->v6_port = add->v6_port;
+	      add->v6_address = NULL;
+	    }
 	}
 
       free(device->name);
@@ -863,7 +1105,14 @@ outputs_device_add(struct output_device *add, bool new_deselect)
       device->has_password = add->has_password;
       device->password = add->password;
 
+      device_state_refresh(device);
       outputs_device_free(add);
+    }
+
+  if (device_has_protocol_variants(device))
+    {
+      device->type_name = airplay_type_name;
+      device_state_refresh(device);
     }
 
   device_list_sort();
@@ -899,6 +1148,9 @@ outputs_device_remove(struct output_device *remove)
 
   if (!device)
     return;
+
+  if (device_has_protocol_variants(remove))
+    device_variant_bind(remove, device_type_effective(remove));
 
   // Save device volume
   ret = db_speaker_save(remove);
@@ -949,18 +1201,23 @@ outputs_device_deselect(struct output_device *device)
 int
 outputs_device_start(struct output_device *device, output_status_cb cb, bool only_probe)
 {
+  enum output_types type;
   int ret;
 
-  if (outputs[device->type]->disabled || !outputs[device->type]->device_start || !outputs[device->type]->device_probe)
+  type = device_type_effective(device);
+  if (device_has_protocol_variants(device))
+    device_variant_bind(device, type);
+
+  if (outputs[type]->disabled || !outputs[type]->device_start || !outputs[type]->device_probe)
     return -1;
 
   if (device->session)
     return 0; // Device is already running, nothing to do
 
   if (only_probe)
-    ret = outputs[device->type]->device_probe(device, callback_add(device, cb));
+    ret = outputs[type]->device_probe(device, callback_add(device, cb));
   else
-    ret = outputs[device->type]->device_start(device, callback_add(device, cb));
+    ret = outputs[type]->device_start(device, callback_add(device, cb));
 
   return device_state_update(device, ret);;
 }
@@ -968,15 +1225,20 @@ outputs_device_start(struct output_device *device, output_status_cb cb, bool onl
 int
 outputs_device_stop(struct output_device *device, output_status_cb cb)
 {
+  enum output_types type;
   int ret;
 
-  if (outputs[device->type]->disabled || !outputs[device->type]->device_stop)
+  type = device_type_effective(device);
+  if (device_has_protocol_variants(device))
+    device_variant_bind(device, type);
+
+  if (outputs[type]->disabled || !outputs[type]->device_stop)
     return -1;
 
   if (!device->session)
     return 0; // Device is already stopped, nothing to do
 
-  ret = outputs[device->type]->device_stop(device, callback_add(device, cb));
+  ret = outputs[type]->device_stop(device, callback_add(device, cb));
 
   return device_state_update(device, ret);
 }
@@ -984,13 +1246,19 @@ outputs_device_stop(struct output_device *device, output_status_cb cb)
 int
 outputs_device_stop_delayed(struct output_device *device, output_status_cb cb)
 {
-  if (outputs[device->type]->disabled || !outputs[device->type]->device_stop)
+  enum output_types type;
+
+  type = device_type_effective(device);
+  if (device_has_protocol_variants(device))
+    device_variant_bind(device, type);
+
+  if (outputs[type]->disabled || !outputs[type]->device_stop)
     return -1;
 
   if (!device->session)
     return 0; // Device is already stopped, nothing to do
 
-  outputs[device->type]->device_cb_set(device, callback_add(device, cb));
+  outputs[type]->device_cb_set(device, callback_add(device, cb));
 
   event_add(device->stop_timer, &outputs_stop_timeout);
 
@@ -1000,15 +1268,20 @@ outputs_device_stop_delayed(struct output_device *device, output_status_cb cb)
 int
 outputs_device_flush(struct output_device *device, output_status_cb cb)
 {
+  enum output_types type;
   int ret;
 
-  if (outputs[device->type]->disabled || !outputs[device->type]->device_flush)
+  type = device_type_effective(device);
+  if (device_has_protocol_variants(device))
+    device_variant_bind(device, type);
+
+  if (outputs[type]->disabled || !outputs[type]->device_flush)
     return -1;
 
   if (!device->session)
     return 0; // Nothing to flush
 
-  ret = outputs[device->type]->device_flush(device, callback_add(device, cb));
+  ret = outputs[type]->device_flush(device, callback_add(device, cb));
 
   return ret; // We don't change device state just because of a failed flush
 }
@@ -1027,15 +1300,20 @@ outputs_device_volume_register(struct output_device *device, int absvol, int rel
 int
 outputs_device_volume_set(struct output_device *device, output_status_cb cb)
 {
+  enum output_types type;
   int ret;
 
-  if (outputs[device->type]->disabled || !outputs[device->type]->device_volume_set)
+  type = device_type_effective(device);
+  if (device_has_protocol_variants(device))
+    device_variant_bind(device, type);
+
+  if (outputs[type]->disabled || !outputs[type]->device_volume_set)
     return -1;
 
   if (!device->session)
     return 0; // Device isn't active
 
-  ret = outputs[device->type]->device_volume_set(device, callback_add(device, cb));
+  ret = outputs[type]->device_volume_set(device, callback_add(device, cb));
 
   return ret; // We don't change device state just because of a failed volume change
 }
@@ -1043,21 +1321,32 @@ outputs_device_volume_set(struct output_device *device, output_status_cb cb)
 int
 outputs_device_volume_to_pct(struct output_device *device, const char *volume)
 {
-  if (outputs[device->type]->disabled || !outputs[device->type]->device_volume_to_pct)
+  enum output_types type;
+
+  type = device_type_effective(device);
+  if (device_has_protocol_variants(device))
+    device_variant_bind(device, type);
+
+  if (outputs[type]->disabled || !outputs[type]->device_volume_to_pct)
     return -1;
 
-  return outputs[device->type]->device_volume_to_pct(device, volume);
+  return outputs[type]->device_volume_to_pct(device, volume);
 }
 
 int
 outputs_device_quality_set(struct output_device *device, struct media_quality *quality, output_status_cb cb)
 {
+  enum output_types type;
   int ret;
 
-  if (outputs[device->type]->disabled || !outputs[device->type]->device_quality_set)
+  type = device_type_effective(device);
+  if (device_has_protocol_variants(device))
+    device_variant_bind(device, type);
+
+  if (outputs[type]->disabled || !outputs[type]->device_quality_set)
     return -1;
 
-  ret = outputs[device->type]->device_quality_set(device, quality, callback_add(device, cb));
+  ret = outputs[type]->device_quality_set(device, quality, callback_add(device, cb));
 
   return device_state_update(device, ret);
 }
@@ -1065,15 +1354,20 @@ outputs_device_quality_set(struct output_device *device, struct media_quality *q
 int
 outputs_device_authorize(struct output_device *device, const char *pin, output_status_cb cb)
 {
+  enum output_types type;
   int ret;
 
-  if (outputs[device->type]->disabled || !outputs[device->type]->device_authorize)
+  type = device_type_effective(device);
+  if (device_has_protocol_variants(device))
+    device_variant_bind(device, type);
+
+  if (outputs[type]->disabled || !outputs[type]->device_authorize)
     return -1;
 
   if (device->session)
     return 0; // We are already connected to the device - no auth required
 
-  ret = outputs[device->type]->device_authorize(device, pin, callback_add(device, cb));
+  ret = outputs[type]->device_authorize(device, pin, callback_add(device, cb));
 
   return device_state_update(device, ret); // If ret < 0 then we couldn't reach the speaker
 }
@@ -1081,20 +1375,31 @@ outputs_device_authorize(struct output_device *device, const char *pin, output_s
 void
 outputs_device_cb_set(struct output_device *device, output_status_cb cb)
 {
-  if (outputs[device->type]->disabled || !outputs[device->type]->device_cb_set)
+  enum output_types type;
+
+  type = device_type_effective(device);
+  if (device_has_protocol_variants(device))
+    device_variant_bind(device, type);
+
+  if (outputs[type]->disabled || !outputs[type]->device_cb_set)
     return;
 
   if (!device->session)
     return;
 
-  outputs[device->type]->device_cb_set(device, callback_add(device, cb));
+  outputs[type]->device_cb_set(device, callback_add(device, cb));
 }
 
 void
 outputs_device_free(struct output_device *device)
 {
+  struct output_device_variant *variant;
+
   if (!device)
     return;
+
+  if (device_has_protocol_variants(device))
+    device_variant_bind(device, device_type_effective(device));
 
   if (outputs[device->type]->disabled)
     DPRINTF(E_LOG, L_PLAYER, "BUG! Freeing device from a disabled output?\n");
@@ -1102,16 +1407,45 @@ outputs_device_free(struct output_device *device)
   if (device->session)
     DPRINTF(E_LOG, L_PLAYER, "BUG! Freeing device with active session?\n");
 
-  if (outputs[device->type]->device_free_extra)
+  if (device->extra_device_info && outputs[device->type]->device_free_extra)
     outputs[device->type]->device_free_extra(device);
+
+  if (device_has_protocol_variants(device))
+    {
+      variant = &device->raop;
+      if (variant->extra_device_info && outputs[OUTPUT_TYPE_RAOP]->device_free_extra)
+	{
+	  device->extra_device_info = variant->extra_device_info;
+	  variant->extra_device_info = NULL;
+	  outputs[OUTPUT_TYPE_RAOP]->device_free_extra(device);
+	  device->extra_device_info = NULL;
+	}
+
+      variant = &device->airplay2;
+      if (variant->extra_device_info && outputs[OUTPUT_TYPE_AIRPLAY]->device_free_extra)
+	{
+	  device->extra_device_info = variant->extra_device_info;
+	  variant->extra_device_info = NULL;
+	  outputs[OUTPUT_TYPE_AIRPLAY]->device_free_extra(device);
+	  device->extra_device_info = NULL;
+	}
+    }
 
   if (device->stop_timer)
     event_free(device->stop_timer);
 
   free(device->name);
   free(device->auth_key);
+  free(device->auth_key_raop);
+  free(device->auth_key_airplay2);
   free(device->v4_address);
   free(device->v6_address);
+  free(device->raop.auth_key);
+  free(device->raop.v4_address);
+  free(device->raop.v6_address);
+  free(device->airplay2.auth_key);
+  free(device->airplay2.v4_address);
+  free(device->airplay2.v6_address);
 
   free(device);
 }
@@ -1297,13 +1631,41 @@ outputs_metadata_purge(void)
 int
 outputs_priority(struct output_device *device)
 {
-  return outputs[device->type]->priority;
+  return outputs[device_type_default_resolve(device)]->priority;
 }
 
 const char *
 outputs_name(enum output_types type)
 {
   return outputs[type]->name;
+}
+
+const char *
+outputs_protocol_to_string(enum output_protocol_preference protocol)
+{
+  switch (protocol)
+    {
+      case OUTPUT_PROTOCOL_RAOP:
+	return "raop";
+      case OUTPUT_PROTOCOL_AIRPLAY2:
+	return "airplay2";
+      case OUTPUT_PROTOCOL_DEFAULT:
+      default:
+	return "default";
+    }
+}
+
+enum output_protocol_preference
+outputs_protocol_from_string(const char *protocol)
+{
+  if (!protocol || strcmp(protocol, "default") == 0)
+    return OUTPUT_PROTOCOL_DEFAULT;
+  if (strcmp(protocol, "raop") == 0)
+    return OUTPUT_PROTOCOL_RAOP;
+  if (strcmp(protocol, "airplay2") == 0)
+    return OUTPUT_PROTOCOL_AIRPLAY2;
+
+  return -1;
 }
 
 struct output_device *
@@ -1406,4 +1768,3 @@ outputs_deinit(void)
   for (i = 0; i < ARRAY_SIZE(output_buffer.data); i++)
     evbuffer_free(output_buffer.data[i].evbuf);
 }
-

--- a/src/outputs.h
+++ b/src/outputs.h
@@ -312,10 +312,16 @@ struct output_device *
 outputs_device_get(uint64_t device_id);
 
 struct output_device *
-outputs_device_get_for_type(uint64_t device_id, enum output_types type);
+outputs_device_get_bound(uint64_t device_id, enum output_types type);
 
 void
 outputs_device_bind(struct output_device *device, enum output_types type);
+
+void
+outputs_device_requires_auth_set(struct output_device *device, bool requires_auth);
+
+void
+outputs_device_v6_disabled_set(struct output_device *device, bool v6_disabled);
 
 void
 outputs_device_refresh(struct output_device *device);

--- a/src/outputs.h
+++ b/src/outputs.h
@@ -45,6 +45,7 @@
 struct output_device;
 struct output_metadata;
 enum output_device_state;
+struct output_device_variant;
 
 typedef void (*output_status_cb)(struct output_device *device, enum output_device_state status);
 typedef int (*output_metadata_finalize_cb)(struct output_metadata *metadata);
@@ -69,6 +70,13 @@ enum output_types
 #endif
 };
 
+enum output_protocol_preference
+{
+  OUTPUT_PROTOCOL_DEFAULT = 0,
+  OUTPUT_PROTOCOL_RAOP,
+  OUTPUT_PROTOCOL_AIRPLAY2,
+};
+
 /* Output session state */
 enum output_device_state
 {
@@ -88,6 +96,21 @@ enum output_device_state
 
 /* Linked list of device info used by the player for each device
  */
+struct output_device_variant
+{
+  bool available;
+  bool advertised;
+  bool requires_auth;
+  bool v6_disabled;
+  char *auth_key;
+  char *v4_address;
+  char *v6_address;
+  short v4_port;
+  short v6_port;
+  void *extra_device_info;
+  void *session;
+};
+
 struct output_device
 {
   // Device id
@@ -116,10 +139,17 @@ struct output_device
   unsigned prevent_playback:1;
   unsigned busy:1;
   unsigned resurrect:1;
+  unsigned supports_raop:1;
+  unsigned supports_airplay2:1;
 
   // Credentials if relevant
   const char *password;
   char *auth_key;
+  char *auth_key_raop;
+  char *auth_key_airplay2;
+
+  enum output_protocol_preference protocol_preference;
+  enum output_types active_type;
 
   // Device volume
   int volume;
@@ -146,6 +176,11 @@ struct output_device
   // Only used for streaming
   int audio_fd;
   int metadata_fd;
+
+  // For AirPlay protocol-capable speakers the common backend fields above are
+  // rebound to the selected variant on demand.
+  struct output_device_variant raop;
+  struct output_device_variant airplay2;
 
   struct event *stop_timer;
 
@@ -276,6 +311,15 @@ struct output_definition
 struct output_device *
 outputs_device_get(uint64_t device_id);
 
+struct output_device *
+outputs_device_get_for_type(uint64_t device_id, enum output_types type);
+
+void
+outputs_device_bind(struct output_device *device, enum output_types type);
+
+void
+outputs_device_refresh(struct output_device *device);
+
 uint64_t
 outputs_buffer_duration_ms_get(void);
 
@@ -390,6 +434,12 @@ outputs_metadata_purge(void);
 
 int
 outputs_priority(struct output_device *device);
+
+const char *
+outputs_protocol_to_string(enum output_protocol_preference protocol);
+
+enum output_protocol_preference
+outputs_protocol_from_string(const char *protocol);
 
 const char *
 outputs_name(enum output_types type);

--- a/src/outputs/airplay.c
+++ b/src/outputs/airplay.c
@@ -614,11 +614,14 @@ device_id_find_byname(uint64_t *id, const char *name)
 
   for (device = outputs_list(); device; device = device->next)
     {
-      if (device->type != OUTPUT_TYPE_AIRPLAY)
-	continue;
+      if (device->supports_airplay2)
+	extra = device->airplay2.extra_device_info;
+      else if (device->type == OUTPUT_TYPE_AIRPLAY)
+	extra = device->extra_device_info;
+      else
+	extra = NULL;
 
-      extra = device->extra_device_info;
-      if (strcmp(name, extra->mdns_name) == 0)
+      if (extra && extra->mdns_name && strcmp(name, extra->mdns_name) == 0)
 	break;
     }
 
@@ -2937,9 +2940,10 @@ payload_make_pair_verify1(struct evrtsp_request *req, struct airplay_session *se
   struct output_device *device;
   char device_id_hex[16 + 1];
 
-  device = outputs_device_get(session->device_id);
+  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     return -1;
+  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   snprintf(device_id_hex, sizeof(device_id_hex), "%016" PRIX64, airplay_device_id);
 
@@ -2967,12 +2971,13 @@ start_failure(struct airplay_session *session)
 {
   struct output_device *device;
 
-  device = outputs_device_get(session->device_id);
+  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     {
       session_failure(session);
       return;
     }
+  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   // If our key was incorrect, or the device reset its pairings, then this
   // function was called because the encrypted request (SETUP) timed out
@@ -2994,12 +2999,13 @@ start_retry(struct airplay_session *session)
   struct output_device *device;
   int callback_id = session->callback_id;
 
-  device = outputs_device_get(session->device_id);
+  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     {
       session_failure(session);
       return;
     }
+  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   // Some devices don't seem to work with ipv6, so if the error wasn't a hard
   // failure (bad password) we fall back to ipv4 and flag device as bad for ipv6
@@ -3277,9 +3283,10 @@ response_handler_info_generic(struct evrtsp_request *req, struct airplay_session
   plist_t item;
   int ret;
 
-  device = outputs_device_get(session->device_id);
+  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     return AIRPLAY_SEQ_ABORT;
+  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   ret = session_ids_set(session);
   if (ret < 0)
@@ -3433,9 +3440,10 @@ response_handler_pair_setup1(struct evrtsp_request *req, struct airplay_session 
 
   if (session->pair_type == PAIR_CLIENT_HOMEKIT_TRANSIENT && req->response_code == RTSP_CONNECTION_AUTH_REQUIRED)
     {
-      device = outputs_device_get(session->device_id);
+      device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
       if (!device)
 	return AIRPLAY_SEQ_ABORT;
+      outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
       device->requires_auth = 1; // FIXME might be reset by mdns announcement
       session->pair_type = PAIR_CLIENT_HOMEKIT_NORMAL;
@@ -3502,9 +3510,10 @@ response_handler_pair_setup3(struct evrtsp_request *req, struct airplay_session 
 
   DPRINTF(E_LOG, L_AIRPLAY, "Pair setup stage complete, saving authorization key\n");
 
-  device = outputs_device_get(session->device_id);
+  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     return AIRPLAY_SEQ_ABORT;
+  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   free(device->auth_key);
   device->auth_key = strdup(authorization_key);
@@ -3529,9 +3538,10 @@ response_handler_pair_verify1(struct evrtsp_request *req, struct airplay_session
     {
       session->state = AIRPLAY_STATE_AUTH;
 
-      device = outputs_device_get(session->device_id);
+      device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
       if (!device)
 	return AIRPLAY_SEQ_ABORT;
+      outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
       // Clear auth_key, the device did not accept it
       free(device->auth_key);
@@ -3572,9 +3582,10 @@ response_handler_pair_verify2(struct evrtsp_request *req, struct airplay_session
   return AIRPLAY_SEQ_CONTINUE;
 
  error:
-  device = outputs_device_get(session->device_id);
+  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     return AIRPLAY_SEQ_ABORT;
+  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   // Clear auth_key, the device did not accept it, or some other unexpected error
   free(device->auth_key);
@@ -4195,6 +4206,9 @@ static void
 airplay_device_free_extra(struct output_device *device)
 {
   struct airplay_extra *extra = device->extra_device_info;
+
+  if (!extra)
+    return;
 
   free(extra->mdns_name);
   free(extra);

--- a/src/outputs/airplay.c
+++ b/src/outputs/airplay.c
@@ -1594,6 +1594,23 @@ session_make(struct output_device *device, int callback_id)
 
   extra = device->extra_device_info;
 
+  DPRINTF(E_SPAM, L_AIRPLAY,
+	  "session_make for device '%s' (%" PRIu64 "): callback_id=%d type=%d active=%d extra=%p session=%p raop_extra=%p airplay2_extra=%p\n",
+	  device->name, device->id, callback_id, device->type, device->active_type, extra, device->session,
+	  device->raop.extra_device_info, device->airplay2.extra_device_info);
+  if (extra)
+    DPRINTF(E_SPAM, L_AIRPLAY,
+	    "session_make extra for device '%s' (%" PRIu64 "): auth_setup=%d wanted_metadata=%u encryption=%d use_ptp=%d transient_pairing=%d\n",
+	    device->name, device->id, extra->supports_auth_setup, extra->wanted_metadata,
+	    extra->supports_encryption, extra->use_ptp, extra->supports_pairing_transient);
+  else
+    {
+      DPRINTF(E_LOG, L_AIRPLAY,
+	      "Bug! Missing AirPlay device info for device '%s' (%" PRIu64 "), type=%d active=%d\n",
+	      device->name, device->id, device->type, device->active_type);
+      return NULL;
+    }
+
   CHECK_NULL(L_AIRPLAY, session = calloc(1, sizeof(struct airplay_session)));
   CHECK_NULL(L_AIRPLAY, session->deferredev = evtimer_new(evbase_player, deferred_session_failure_cb, session));
 
@@ -4128,6 +4145,10 @@ airplay_device_cb(const char *name, const char *type, const char *domain, const 
   if (ret < 0)
     goto free_device;
 
+  DPRINTF(E_SPAM, L_AIRPLAY,
+	  "Queued AirPlay add for '%s' (%" PRIu64 "): extra=%p wanted_metadata=%u auth_setup=%d encryption=%d use_ptp=%d family=%d port=%d\n",
+	  device->name, device->id, extra, extra->wanted_metadata, extra->supports_auth_setup, extra->supports_encryption, extra->use_ptp, family, port);
+
   return;
 
  free_device:
@@ -4158,6 +4179,10 @@ airplay_device_start(struct output_device *device, int callback_id)
 {
   struct airplay_session *session;
 
+  DPRINTF(E_SPAM, L_AIRPLAY,
+	  "airplay_device_start for '%s' (%" PRIu64 "): callback_id=%d type=%d active=%d extra=%p session=%p\n",
+	  device->name, device->id, callback_id, device->type, device->active_type, device->extra_device_info, device->session);
+
   session = session_make(device, callback_id);
   if (!session)
     return -1;
@@ -4171,6 +4196,10 @@ static int
 airplay_device_stop(struct output_device *device, int callback_id)
 {
   struct airplay_session *session = device->session;
+
+  DPRINTF(E_SPAM, L_AIRPLAY,
+	  "airplay_device_stop for '%s' (%" PRIu64 "): callback_id=%d type=%d active=%d extra=%p session=%p\n",
+	  device->name, device->id, callback_id, device->type, device->active_type, device->extra_device_info, session);
 
   session->callback_id = callback_id;
 

--- a/src/outputs/airplay.c
+++ b/src/outputs/airplay.c
@@ -2957,10 +2957,9 @@ payload_make_pair_verify1(struct evrtsp_request *req, struct airplay_session *se
   struct output_device *device;
   char device_id_hex[16 + 1];
 
-  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
+  device = outputs_device_get_bound(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     return -1;
-  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   snprintf(device_id_hex, sizeof(device_id_hex), "%016" PRIX64, airplay_device_id);
 
@@ -2988,13 +2987,12 @@ start_failure(struct airplay_session *session)
 {
   struct output_device *device;
 
-  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
+  device = outputs_device_get_bound(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     {
       session_failure(session);
       return;
     }
-  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   // If our key was incorrect, or the device reset its pairings, then this
   // function was called because the encrypted request (SETUP) timed out
@@ -3004,7 +3002,7 @@ start_failure(struct airplay_session *session)
 
       free(device->auth_key);
       device->auth_key = NULL;
-      device->requires_auth = 1;
+      outputs_device_requires_auth_set(device, true);
     }
 
   session_failure(session);
@@ -3016,13 +3014,12 @@ start_retry(struct airplay_session *session)
   struct output_device *device;
   int callback_id = session->callback_id;
 
-  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
+  device = outputs_device_get_bound(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     {
       session_failure(session);
       return;
     }
-  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   // Some devices don't seem to work with ipv6, so if the error wasn't a hard
   // failure (bad password) we fall back to ipv4 and flag device as bad for ipv6
@@ -3033,7 +3030,7 @@ start_retry(struct airplay_session *session)
     }
 
   // This flag is permanent and will not be overwritten by mdns advertisements
-  device->v6_disabled = 1;
+  outputs_device_v6_disabled_set(device, true);
 
   // Drop session, try again with ipv4
   session_cleanup(session);
@@ -3300,10 +3297,9 @@ response_handler_info_generic(struct evrtsp_request *req, struct airplay_session
   plist_t item;
   int ret;
 
-  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
+  device = outputs_device_get_bound(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     return AIRPLAY_SEQ_ABORT;
-  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   ret = session_ids_set(session);
   if (ret < 0)
@@ -3336,7 +3332,7 @@ response_handler_info_generic(struct evrtsp_request *req, struct airplay_session
 
       if (!device->auth_key)
 	{
-	  device->requires_auth = 1;
+	  outputs_device_requires_auth_set(device, true);
           session->state = AIRPLAY_STATE_AUTH;
 	  return AIRPLAY_SEQ_PIN_START;
 	}
@@ -3348,7 +3344,7 @@ response_handler_info_generic(struct evrtsp_request *req, struct airplay_session
     {
       free(device->auth_key);
       device->auth_key = NULL;
-      device->requires_auth = 1;
+      outputs_device_requires_auth_set(device, true);
 
       session->pair_type = PAIR_CLIENT_HOMEKIT_NORMAL;
       session->state = AIRPLAY_STATE_AUTH;
@@ -3457,12 +3453,11 @@ response_handler_pair_setup1(struct evrtsp_request *req, struct airplay_session 
 
   if (session->pair_type == PAIR_CLIENT_HOMEKIT_TRANSIENT && req->response_code == RTSP_CONNECTION_AUTH_REQUIRED)
     {
-      device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
+      device = outputs_device_get_bound(session->device_id, OUTPUT_TYPE_AIRPLAY);
       if (!device)
 	return AIRPLAY_SEQ_ABORT;
-      outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
-      device->requires_auth = 1; // FIXME might be reset by mdns announcement
+      outputs_device_requires_auth_set(device, true);
       session->pair_type = PAIR_CLIENT_HOMEKIT_NORMAL;
 
       return AIRPLAY_SEQ_PIN_START;
@@ -3527,10 +3522,9 @@ response_handler_pair_setup3(struct evrtsp_request *req, struct airplay_session 
 
   DPRINTF(E_LOG, L_AIRPLAY, "Pair setup stage complete, saving authorization key\n");
 
-  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
+  device = outputs_device_get_bound(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     return AIRPLAY_SEQ_ABORT;
-  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   free(device->auth_key);
   device->auth_key = strdup(authorization_key);
@@ -3555,10 +3549,9 @@ response_handler_pair_verify1(struct evrtsp_request *req, struct airplay_session
     {
       session->state = AIRPLAY_STATE_AUTH;
 
-      device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
+      device = outputs_device_get_bound(session->device_id, OUTPUT_TYPE_AIRPLAY);
       if (!device)
 	return AIRPLAY_SEQ_ABORT;
-      outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
       // Clear auth_key, the device did not accept it
       free(device->auth_key);
@@ -3599,10 +3592,9 @@ response_handler_pair_verify2(struct evrtsp_request *req, struct airplay_session
   return AIRPLAY_SEQ_CONTINUE;
 
  error:
-  device = outputs_device_get_for_type(session->device_id, OUTPUT_TYPE_AIRPLAY);
+  device = outputs_device_get_bound(session->device_id, OUTPUT_TYPE_AIRPLAY);
   if (!device)
     return AIRPLAY_SEQ_ABORT;
-  outputs_device_bind(device, OUTPUT_TYPE_AIRPLAY);
 
   // Clear auth_key, the device did not accept it, or some other unexpected error
   free(device->auth_key);

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -2666,13 +2666,14 @@ raop_set_volume_internal(struct raop_session *rs, int volume, evrtsp_req_cb cb)
   float raop_volume;
   int ret;
 
-  device = outputs_device_get(rs->device_id);
+  device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
   if (!device)
     {
       DPRINTF(E_LOG, L_RAOP, "Could not set volume, device with id %" PRIu64 " not in out list\n", rs->device_id);
 
       return -1;
     }
+  outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
   evbuf = evbuffer_new();
   if (!evbuf)
@@ -3284,12 +3285,13 @@ raop_cb_startup_retry(struct evrtsp_request *req, void *arg)
   struct output_device *device;
   int callback_id = rs->callback_id;
 
-  device = outputs_device_get(rs->device_id);
+  device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
   if (!device)
     {
       session_failure(rs);
       return;
     }
+  outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
   session_cleanup(rs);
   raop_device_start(device, callback_id);
@@ -3309,12 +3311,13 @@ raop_startup_cancel(struct raop_session *rs)
   struct output_device *device;
   int ret;
 
-  device = outputs_device_get(rs->device_id);
+  device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
   if (!device || !rs->session)
     {
       session_failure(rs);
       return;
     }
+  outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
   // Some devices don't seem to work with ipv6, so if the error wasn't a hard
   // failure (bad password) we fall back to ipv4 and flag device as bad for ipv6
@@ -3721,9 +3724,10 @@ raop_cb_startup_options(struct evrtsp_request *req, void *arg)
 
   if (req->response_code == RTSP_FORBIDDEN)
     {
-      device = outputs_device_get(rs->device_id);
+      device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
       if (!device)
 	goto cleanup;
+      outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
       device->requires_auth = 1;
 
@@ -3939,9 +3943,10 @@ raop_cb_pair_verify_step2(struct evrtsp_request *req, void *arg)
   ret = raop_pair_response_process(5, req, rs);
   if (ret < 0)
     {
-      device = outputs_device_get(rs->device_id);
+      device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
       if (!device)
 	goto error;
+      outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
       // Clear auth_key, the device did not accept it
       free(device->auth_key);
@@ -3972,9 +3977,10 @@ raop_cb_pair_verify_step1(struct evrtsp_request *req, void *arg)
   ret = raop_pair_response_process(4, req, rs);
   if (ret < 0)
     {
-      device = outputs_device_get(rs->device_id);
+      device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
       if (!device)
 	goto error;
+      outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
       // Clear auth_key, the device did not accept it
       free(device->auth_key);
@@ -4002,9 +4008,10 @@ raop_pair_verify(struct raop_session *rs)
   struct output_device *device;
   int ret;
 
-  device = outputs_device_get(rs->device_id);
+  device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
   if (!device)
     goto error;
+  outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
   rs->pair_verify_ctx = pair_verify_new(PAIR_CLIENT_FRUIT, device->auth_key, NULL, NULL, NULL);
   if (!rs->pair_verify_ctx)
@@ -4049,9 +4056,10 @@ raop_cb_pair_setup_step3(struct evrtsp_request *req, void *arg)
 
   DPRINTF(E_LOG, L_RAOP, "Verification setup stage complete, saving authorization key\n");
 
-  device = outputs_device_get(rs->device_id);
+  device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
   if (!device)
     goto out;
+  outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
   free(device->auth_key);
   device->auth_key = strdup(authorization_key);
@@ -4581,6 +4589,9 @@ static void
 raop_device_free_extra(struct output_device *device)
 {
   struct raop_extra *re = device->extra_device_info;
+
+  if (!re)
+    return;
 
   free(re);
 }

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -2666,14 +2666,13 @@ raop_set_volume_internal(struct raop_session *rs, int volume, evrtsp_req_cb cb)
   float raop_volume;
   int ret;
 
-  device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
+  device = outputs_device_get_bound(rs->device_id, OUTPUT_TYPE_RAOP);
   if (!device)
     {
       DPRINTF(E_LOG, L_RAOP, "Could not set volume, device with id %" PRIu64 " not in out list\n", rs->device_id);
 
       return -1;
     }
-  outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
   evbuf = evbuffer_new();
   if (!evbuf)
@@ -3285,13 +3284,12 @@ raop_cb_startup_retry(struct evrtsp_request *req, void *arg)
   struct output_device *device;
   int callback_id = rs->callback_id;
 
-  device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
+  device = outputs_device_get_bound(rs->device_id, OUTPUT_TYPE_RAOP);
   if (!device)
     {
       session_failure(rs);
       return;
     }
-  outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
   session_cleanup(rs);
   raop_device_start(device, callback_id);
@@ -3311,20 +3309,19 @@ raop_startup_cancel(struct raop_session *rs)
   struct output_device *device;
   int ret;
 
-  device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
+  device = outputs_device_get_bound(rs->device_id, OUTPUT_TYPE_RAOP);
   if (!device || !rs->session)
     {
       session_failure(rs);
       return;
     }
-  outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
   // Some devices don't seem to work with ipv6, so if the error wasn't a hard
   // failure (bad password) we fall back to ipv4 and flag device as bad for ipv6
   if (rs->family == AF_INET6 && !(rs->state & RAOP_STATE_F_FAILED))
     {
       // This flag is permanent and will not be overwritten by mdns advertisements
-      device->v6_disabled = 1;
+      outputs_device_v6_disabled_set(device, true);
 
       // Stop current session and wait for call back
       ret = raop_send_req_teardown(rs, raop_cb_startup_retry, "startup_cancel");
@@ -3724,12 +3721,11 @@ raop_cb_startup_options(struct evrtsp_request *req, void *arg)
 
   if (req->response_code == RTSP_FORBIDDEN)
     {
-      device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
+      device = outputs_device_get_bound(rs->device_id, OUTPUT_TYPE_RAOP);
       if (!device)
 	goto cleanup;
-      outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
-      device->requires_auth = 1;
+      outputs_device_requires_auth_set(device, true);
 
       ret = raop_send_req_pin_start(rs, raop_cb_pin_start, "startup_options");
       if (ret < 0)
@@ -3943,10 +3939,9 @@ raop_cb_pair_verify_step2(struct evrtsp_request *req, void *arg)
   ret = raop_pair_response_process(5, req, rs);
   if (ret < 0)
     {
-      device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
+      device = outputs_device_get_bound(rs->device_id, OUTPUT_TYPE_RAOP);
       if (!device)
 	goto error;
-      outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
       // Clear auth_key, the device did not accept it
       free(device->auth_key);
@@ -3977,10 +3972,9 @@ raop_cb_pair_verify_step1(struct evrtsp_request *req, void *arg)
   ret = raop_pair_response_process(4, req, rs);
   if (ret < 0)
     {
-      device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
+      device = outputs_device_get_bound(rs->device_id, OUTPUT_TYPE_RAOP);
       if (!device)
 	goto error;
-      outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
       // Clear auth_key, the device did not accept it
       free(device->auth_key);
@@ -4008,10 +4002,9 @@ raop_pair_verify(struct raop_session *rs)
   struct output_device *device;
   int ret;
 
-  device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
+  device = outputs_device_get_bound(rs->device_id, OUTPUT_TYPE_RAOP);
   if (!device)
     goto error;
-  outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
   rs->pair_verify_ctx = pair_verify_new(PAIR_CLIENT_FRUIT, device->auth_key, NULL, NULL, NULL);
   if (!rs->pair_verify_ctx)
@@ -4056,10 +4049,9 @@ raop_cb_pair_setup_step3(struct evrtsp_request *req, void *arg)
 
   DPRINTF(E_LOG, L_RAOP, "Verification setup stage complete, saving authorization key\n");
 
-  device = outputs_device_get_for_type(rs->device_id, OUTPUT_TYPE_RAOP);
+  device = outputs_device_get_bound(rs->device_id, OUTPUT_TYPE_RAOP);
   if (!device)
     goto out;
-  outputs_device_bind(device, OUTPUT_TYPE_RAOP);
 
   free(device->auth_key);
   device->auth_key = strdup(authorization_key);

--- a/src/player.c
+++ b/src/player.c
@@ -1656,6 +1656,10 @@ device_shutdown_cb(struct output_device *device, enum output_device_state status
     }
 
   DPRINTF(E_DBG, L_PLAYER, "Callback from %s device %s to device_shutdown_cb (status %d)\n", device->type_name, device->name, status);
+  DPRINTF(E_SPAM, L_PLAYER,
+	  "Shutdown callback device '%s' (%" PRIu64 "): type=%d active=%d status=%d live(extra=%p session=%p) raop(extra=%p session=%p) airplay2(extra=%p session=%p)\n",
+	  device->name, device->id, device->type, device->active_type, status, device->extra_device_info, device->session,
+	  device->raop.extra_device_info, device->raop.session, device->airplay2.extra_device_info, device->airplay2.session);
 
  out:
   commands_exec_end(cmdbase, retval);

--- a/src/player.c
+++ b/src/player.c
@@ -154,6 +154,7 @@ struct speaker_attr_param
 
   struct media_quality quality;
   enum media_format format;
+  enum output_protocol_preference protocol;
   int offset_ms;
 
   int audio_fd;
@@ -1417,6 +1418,8 @@ device_remove_family(void *arg, int *retval)
   union player_arg *cmdarg = arg;
   struct output_device *remove;
   struct output_device *device;
+  struct output_device_variant *variant;
+  bool variant_bound;
 
   remove = cmdarg->device;
 
@@ -1431,24 +1434,66 @@ device_remove_family(void *arg, int *retval)
     }
 
   // v{4,6}_port non-zero indicates the address family stopped advertising
-  if (remove->v4_port && device->v4_address)
+  variant = NULL;
+  if (remove->type == OUTPUT_TYPE_RAOP)
+    variant = &device->raop;
+  else if (remove->type == OUTPUT_TYPE_AIRPLAY)
+    variant = &device->airplay2;
+  variant_bound = (variant && device->type == remove->type);
+
+  if (remove->v4_port && variant && variant->v4_address)
+    {
+      free(variant->v4_address);
+      variant->v4_address = NULL;
+      variant->v4_port = 0;
+
+      if (variant_bound)
+	{
+	  free(device->v4_address);
+	  device->v4_address = NULL;
+	  device->v4_port = 0;
+	}
+    }
+  else if (remove->v4_port && !variant && device->v4_address)
     {
       free(device->v4_address);
       device->v4_address = NULL;
       device->v4_port = 0;
     }
 
-  if (remove->v6_port && device->v6_address)
+  if (remove->v6_port && variant && variant->v6_address)
+    {
+      free(variant->v6_address);
+      variant->v6_address = NULL;
+      variant->v6_port = 0;
+
+      if (variant_bound)
+	{
+	  free(device->v6_address);
+	  device->v6_address = NULL;
+	  device->v6_port = 0;
+	}
+    }
+  else if (remove->v6_port && !variant && device->v6_address)
     {
       free(device->v6_address);
       device->v6_address = NULL;
       device->v6_port = 0;
     }
 
-  if (!device->v4_address && !device->v6_address)
+  if (variant)
+    {
+      variant->advertised = (variant->v4_address || variant->v6_address);
+      variant->available = variant->advertised;
+      outputs_device_refresh(device);
+    }
+  else if (!device->v4_address && !device->v6_address)
     {
       device->advertised = 0;
+    }
 
+  if (!device->advertised)
+    {
       // If there is a session we will keep the device in the list until the
       // backend gives us a callback with a failure. Then outputs.c will remove
       // the device. If the output backend never gives a callback (can that
@@ -2553,6 +2598,8 @@ device_to_speaker_info(struct player_speaker_info *spk, struct output_device *de
   spk->offset_ms = device->offset_ms;
 
   spk->supported_formats = device->supported_formats;
+  strncpy(spk->protocol, outputs_protocol_to_string(device->protocol_preference), sizeof(spk->protocol));
+  spk->protocol[sizeof(spk->protocol) - 1] = '\0';
   // Devices supporting more than one format should at least have default_format set
   if (device->selected_format != MEDIA_FORMAT_UNKNOWN)
     spk->format = device->selected_format;
@@ -2567,6 +2614,8 @@ device_to_speaker_info(struct player_speaker_info *spk, struct output_device *de
   spk->has_video = device->has_video;
   spk->requires_auth = device->requires_auth;
   spk->needs_auth_key = (device->requires_auth && device->auth_key == NULL);
+  spk->supports_raop = device->supports_raop;
+  spk->supports_airplay2 = device->supports_airplay2;
   spk->prevent_playback = device->prevent_playback;
   spk->busy = device->busy;
 }
@@ -3027,6 +3076,39 @@ speaker_authorize(void *arg, int *retval)
   if (*retval > 0)
     return COMMAND_PENDING; // async
 
+  return COMMAND_END;
+}
+
+static enum command_state
+speaker_protocol_set(void *arg, int *retval)
+{
+  struct speaker_attr_param *param = arg;
+  struct output_device *device;
+
+  *retval = -1;
+
+  device = outputs_device_get(param->spk_id);
+  if (!device)
+    return COMMAND_END;
+
+  if (!device->supports_raop && !device->supports_airplay2)
+    return COMMAND_END;
+
+  if (param->protocol == OUTPUT_PROTOCOL_RAOP && !device->supports_raop)
+    return COMMAND_END;
+
+  if (param->protocol == OUTPUT_PROTOCOL_AIRPLAY2 && !device->supports_airplay2)
+    return COMMAND_END;
+
+  device->protocol_preference = param->protocol;
+  if (!device->session)
+    outputs_device_refresh(device);
+
+  *retval = db_speaker_save(device);
+  if (*retval < 0)
+    return COMMAND_END;
+
+  *retval = 0;
   return COMMAND_END;
 }
 
@@ -3637,6 +3719,17 @@ player_speaker_resurrect(void *arg)
   param.device_ids = (uint64_t *)arg;
 
   commands_exec_sync(cmdbase, speaker_resurrect, speaker_resurrect_bh, &param);
+}
+
+int
+player_speaker_protocol_set(uint64_t id, enum output_protocol_preference protocol)
+{
+  struct speaker_attr_param param;
+
+  param.spk_id = id;
+  param.protocol = protocol;
+
+  return commands_exec_sync(cmdbase, speaker_protocol_set, speaker_generic_bh, &param);
 }
 
 int

--- a/src/player.h
+++ b/src/player.h
@@ -7,6 +7,7 @@
 
 #include "db.h"
 #include "misc.h" // for struct media_quality
+#include "outputs.h"
 
 // Maximum number of previously played songs that are remembered
 #define MAX_HISTORY_COUNT 20
@@ -40,11 +41,14 @@ struct player_speaker_info {
 
   enum media_format format;
   uint32_t supported_formats;
+  char protocol[16];
 
   bool selected;
   bool has_password;
   bool requires_auth;
   bool needs_auth_key;
+  bool supports_raop;
+  bool supports_airplay2;
 
   bool prevent_playback;
   bool busy;
@@ -128,6 +132,9 @@ player_speaker_resurrect(void *arg);
 
 int
 player_speaker_authorize(uint64_t id, const char *pin);
+
+int
+player_speaker_protocol_set(uint64_t id, enum output_protocol_preference protocol);
 
 int
 player_speaker_format_set(uint64_t id, enum media_format format);

--- a/src/ptpd.c
+++ b/src/ptpd.c
@@ -106,7 +106,15 @@ ptpd_init(uint64_t clock_id_seed)
   airptp_callbacks_register(&cb);
 
   if (airptp_create_own_service)
-    return airptp_daemon_start(ptpd_hdl, clock_id_seed, false);
+    {
+      if (!ptpd_hdl)
+	{
+	  DPRINTF(E_LOG, L_AIRPLAY, "Can't start own ptp service, daemon handle is missing\n");
+	  return -1;
+	}
+
+      return airptp_daemon_start(ptpd_hdl, clock_id_seed, false);
+    }
 
   if (!ptpd_hdl)
     ptpd_hdl = airptp_daemon_find();

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -415,9 +415,6 @@ websocket(void *arg)
 {
   thread_setname("websocket");
 
-  listener_add(listener_cb, LISTENER_UPDATE | LISTENER_DATABASE | LISTENER_PAIRING | LISTENER_SPOTIFY | LISTENER_LASTFM | LISTENER_SPEAKER
-               | LISTENER_PLAYER | LISTENER_OPTIONS | LISTENER_VOLUME | LISTENER_QUEUE, NULL);
-
   while(!websocket_exit)
   {
 #if LWS_LIBRARY_VERSION_MAJOR >= 3
@@ -429,8 +426,6 @@ websocket(void *arg)
       lws_callback_on_writable_all_protocol(websocket_context, &protocols[WS_PROTOCOL_NOTIFY]);
 #endif
   }
-
-  listener_remove(listener_cb);
 
   pthread_exit(NULL);
 }
@@ -530,10 +525,21 @@ websocket_init(void)
       return -1;
     }
 
+  ret = listener_add(listener_cb, LISTENER_UPDATE | LISTENER_DATABASE | LISTENER_PAIRING | LISTENER_SPOTIFY | LISTENER_LASTFM | LISTENER_SPEAKER
+                     | LISTENER_PLAYER | LISTENER_OPTIONS | LISTENER_VOLUME | LISTENER_QUEUE, NULL);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "Could not register websocket listener\n");
+      pthread_mutex_destroy(&websocket_write_event_lock);
+      lws_context_destroy(websocket_context);
+      return -1;
+    }
+
   ret = pthread_create(&tid_websocket, NULL, websocket, NULL);
   if (ret < 0)
     {
       DPRINTF(E_LOG, L_WEB, "Could not spawn websocket thread (%d): %s\n", ret, strerror(ret));
+      listener_remove(listener_cb);
       pthread_mutex_destroy(&websocket_write_event_lock);
       lws_context_destroy(websocket_context);
       return -1;
@@ -553,6 +559,7 @@ websocket_deinit(void)
     return;
 
   websocket_is_initialized = false;
+  listener_remove(listener_cb);
   websocket_exit = true;
   lws_cancel_service(websocket_context);
   ret = pthread_join(tid_websocket, NULL);


### PR DESCRIPTION
Summary
This PR adds API support for choosing which protocol to use for an AirPlay-capable speaker (default, raop, or airplay2), and updates output selection so protocol choice is deferred until activation instead of being fixed at discovery time. To support this, raop and airplay2 are recorded as discovered and no longer trimmed.

Note - also covers the bug fixed in 5b19dcb, but checks !ptpd_hdl explicitly, logs an error, and returns -1 before calling airptp_daemon_start instead.

Changes:

- Add supports_raop, supports_airplay2, and protocol to GET /api/outputs and GET /api/outputs/{id}
- Accept protocol: "default" | "raop" | "airplay2" in PUT /api/outputs/{id}
- Persist per-speaker protocol preference in the database
- Keep one logical AirPlay speaker with per-protocol backend state instead of collapsing dual-protocol devices on discovery
- Defer RAOP vs AirPlay 2 selection until speaker enable/start
- Store authorization keys per protocol so RAOP and AirPlay 2 pairing remain independent
- Fix same-type variant rebinding so active state is not accidentally clobbered
- Add defensive diagnostics around variant sync/bind and AirPlay lifecycle transitions
- Harden a couple of null/failure paths in AirPlay/PTP startup

Reasoning:
To expand capability for API-only clients.

Notes:

1. Existing clients that do not send protocol continue to work as before. Likewise, default preserves the existing fallback behavior, including compile-time/default protocol preference logic.
2. If a stored preference is unavailable for a speaker, OwnTone falls back to the existing default-resolution path
3. Protocol preference is persisted per speaker in the speakers table.
