### PR TITLE
timespec_sub() bugfix

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1771,7 +1771,7 @@ timespec_sub(struct timespec time1, struct timespec time2)
 
   result.tv_sec = time1.tv_sec - time2.tv_sec;
   result.tv_nsec = time1.tv_nsec - time2.tv_nsec;
-  if (result.tv_nsec < 0)
+  if (result.tv_nsec < 0 && result.tv_sec != 0)
     {
       result.tv_sec--;
       result.tv_nsec += 1000000000L;


### PR DESCRIPTION
When t1 - t2 is less than 0 seconds and greater than -1 seconds, then it is valid to have a negative tv_nsec value.