### PR TITLE
[Spotify] Audiobook support

### DIFF
--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -2070,9 +2070,10 @@ saved_chapters_add(json_object *item, int index, int total, enum spotify_request
   if (!chapter.type || strcmp(chapter.type, "chapter") != 0)
     chapter.type = "chapter";
 
-  // If there is no chapter name, default to "Chapter N" instead of leaving it
-  // blank (which would result in "Unknown title" or a generic "Track N" label)
-  if (!chapter.name || chapter.name[0] == '\0')
+  // If the chapter has no name, or Spotify returned a generic "Track N" style
+  // name, replace it with "Chapter N" which is more appropriate for audiobooks
+  if (!chapter.name || chapter.name[0] == '\0'
+      || strncasecmp(chapter.name, "Track ", strlen("Track ")) == 0)
     {
       snprintf(chapter_name, sizeof(chapter_name), "Chapter %d", chapter.track_number);
       chapter.name = chapter_name;

--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -1788,20 +1788,13 @@ map_track_to_mfi(struct media_file_info *mfi, const struct spotify_track *track,
 
   mfi->data_kind   = DATA_KIND_SPOTIFY;
   if (!track->type)
-    {
-      DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) has NULL type, defaulting to MUSIC\n", track->name, track->uri);
-      mfi->media_kind  = MEDIA_KIND_MUSIC;
-    }
+    mfi->media_kind  = MEDIA_KIND_MUSIC;
   else if (strcmp(track->type, "episode") == 0)
     mfi->media_kind  = MEDIA_KIND_PODCAST;
   else if (strcmp(track->type, "chapter") == 0)
     mfi->media_kind  = MEDIA_KIND_AUDIOBOOK;
   else
-    {
-      DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) has unknown type '%s', defaulting to MUSIC\n", track->name, track->uri, track->type);
-      mfi->media_kind  = MEDIA_KIND_MUSIC;
-    }
-  DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' mapped to media_kind=%d (type=%s)\n", track->name, mfi->media_kind, track->type ? track->type : "(null)");
+    mfi->media_kind  = MEDIA_KIND_MUSIC;
   mfi->type        = strdup("spotify");
   mfi->codectype   = strdup("wav");
   mfi->description = strdup("Spotify audio");
@@ -1862,17 +1855,14 @@ track_add(struct spotify_track *track, struct spotify_album *album, const char *
       return -1;
     }
 
-  DPRINTF(E_DBG, L_SPOTIFY, "track_add: '%s' by '%s' (uri: %s, type: %s, playable: %d)\n",
-	  track->name, track->artist, track->uri, track->type ? track->type : "(null)", track->is_playable);
-
   if (track->linked_from_uri)
     DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) linked from %s\n", track->name, track->uri, track->linked_from_uri);
 
   ret = db_file_ping_bypath(track->uri, track->mtime);
   if (ret == 0 || request_type == SPOTIFY_REQUEST_TYPE_METARESCAN)
     {
-      DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) is new or modified (mtime is %" PRIi64 ", ping returned %d)\n",
-	      track->name, track->uri, (int64_t)track->mtime, ret);
+      DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) is new or modified (mtime is %" PRIi64 ")\n",
+	      track->name, track->uri, (int64_t)track->mtime);
 
       memset(&mfi, 0, sizeof(struct media_file_info));
 
@@ -1883,15 +1873,7 @@ track_add(struct spotify_track *track, struct spotify_album *album, const char *
 
       library_media_save(&mfi);
 
-      DPRINTF(E_DBG, L_SPOTIFY, "Saved track '%s' to db (id=%d, dir_id=%d, media_kind=%d)\n",
-	      track->name, mfi.id, mfi.directory_id, mfi.media_kind);
-
       free_mfi(&mfi, 1);
-    }
-  else
-    {
-      DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) unchanged, skipping save (ping returned %d)\n",
-	      track->name, track->uri, ret);
     }
 
   if (album && album->uri)
@@ -2080,22 +2062,12 @@ saved_chapters_add(json_object *item, int index, int total, enum spotify_request
   struct spotify_track chapter;
   int dir_id;
 
-  DPRINTF(E_DBG, L_SPOTIFY, "saved_chapters_add: %s\n", json_object_to_json_string(item));
-
   // Map chapter information
   parse_metadata_chapter(item, &chapter, 0);
 
-  DPRINTF(E_DBG, L_SPOTIFY, "Chapter %d/%d: '%s' (uri: %s, type: %s, duration: %dms, playable: %d)\n",
-	  index + 1, total, chapter.name, chapter.uri, chapter.type ? chapter.type : "(null)",
-	  chapter.duration_ms, chapter.is_playable);
-
   // Ensure type is "chapter" so map_track_to_mfi sets MEDIA_KIND_AUDIOBOOK
   if (!chapter.type || strcmp(chapter.type, "chapter") != 0)
-    {
-      DPRINTF(E_DBG, L_SPOTIFY, "Overriding chapter type from '%s' to 'chapter' for '%s'\n",
-	      chapter.type ? chapter.type : "(null)", chapter.name);
-      chapter.type = "chapter";
-    }
+    chapter.type = "chapter";
 
   // Get or create the directory structure for this audiobook
   dir_id = prepare_directories(audiobook->artist, audiobook->name);
@@ -2121,30 +2093,20 @@ saved_audiobook_add(json_object *item, int index, int total, enum spotify_reques
   char *endpoint_uri;
   int ret;
 
-  DPRINTF(E_DBG, L_SPOTIFY, "saved_audiobook_add: %s\n", json_object_to_json_string(item));
-
   // The saved audiobooks endpoint wraps each audiobook in an object, but
   // unlike shows/albums there is no wrapper key - the items ARE the audiobooks
   // directly according to the Spotify API docs for GET /me/audiobooks.
   // However, let's check if there's an "audiobook" wrapper first for safety.
-  if (json_object_object_get_ex(item, "audiobook", &jsonaudiobook))
-    {
-      DPRINTF(E_DBG, L_SPOTIFY, "Found 'audiobook' wrapper in saved audiobook item\n");
-    }
-  else
-    {
-      // Items are audiobook objects directly
-      jsonaudiobook = item;
-    }
+  if (!json_object_object_get_ex(item, "audiobook", &jsonaudiobook))
+    jsonaudiobook = item;
 
   // Map audiobook information
   parse_metadata_audiobook(jsonaudiobook, &audiobook);
   audiobook.added_at = jparse_str_from_obj(item, "added_at");
   audiobook.mtime = jparse_time_from_obj(item, "added_at");
 
-  DPRINTF(E_DBG, L_SPOTIFY, "Processing audiobook %d/%d: '%s' by '%s' (id: %s, uri: %s, type: %s)\n",
-	  index + 1, total, audiobook.name, audiobook.artist, audiobook.id, audiobook.uri,
-	  audiobook.type ? audiobook.type : "(null)");
+  DPRINTF(E_DBG, L_SPOTIFY, "Processing audiobook %d/%d: '%s' by '%s'\n",
+	  index + 1, total, audiobook.name, audiobook.artist);
 
   if (!audiobook.id || !audiobook.uri)
     {
@@ -2156,8 +2118,6 @@ saved_audiobook_add(json_object *item, int index, int total, enum spotify_reques
   endpoint_uri = safe_asprintf(spotify_audiobook_chapters_uri, audiobook.id);
   ret = request_pagingobject_endpoint(endpoint_uri, saved_chapters_add, transaction_start, transaction_end, true, request_type, &audiobook);
   free(endpoint_uri);
-
-  DPRINTF(E_DBG, L_SPOTIFY, "Audiobook '%s' chapters fetch returned %d\n", audiobook.name, ret);
 
   if ((index + 1) >= total || ((index + 1) % 10 == 0))
     DPRINTF(E_DBG, L_SPOTIFY, "Scanned %d of %d saved audiobooks\n", (index + 1), total);

--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -2100,7 +2100,10 @@ saved_chapters_add(json_object *item, int index, int total, enum spotify_request
   // Get or create the directory structure for this audiobook
   dir_id = prepare_directories(audiobook->artist, audiobook->name);
 
-  track_add(&chapter, audiobook, NULL, dir_id, request_type);
+  // Force re-save (METARESCAN) because chapters use spotify:episode: URIs which
+  // may already exist in the DB as podcasts with media_kind=PODCAST. We need to
+  // ensure they are re-saved with media_kind=AUDIOBOOK.
+  track_add(&chapter, audiobook, NULL, dir_id, SPOTIFY_REQUEST_TYPE_METARESCAN);
 
   return 0;
 }

--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -51,6 +51,8 @@ enum spotify_item_type {
   SPOTIFY_ITEM_TYPE_PLAYLIST,
   SPOTIFY_ITEM_TYPE_SHOW,
   SPOTIFY_ITEM_TYPE_EPISODE,
+  SPOTIFY_ITEM_TYPE_AUDIOBOOK,
+  SPOTIFY_ITEM_TYPE_CHAPTER,
 
   SPOTIFY_ITEM_TYPE_UNKNOWN,
 };
@@ -168,6 +170,10 @@ static const char *spotify_artist_albums_uri   = "https://api.spotify.com/v1/art
 static const char *spotify_shows_uri           = "https://api.spotify.com/v1/me/shows?limit=50";
 static const char *spotify_shows_episodes_uri  = "https://api.spotify.com/v1/shows/%s/episodes";
 static const char *spotify_episode_uri         = "https://api.spotify.com/v1/episodes/%s";
+static const char *spotify_audiobooks_uri           = "https://api.spotify.com/v1/me/audiobooks?limit=50";
+static const char *spotify_audiobook_uri            = "https://api.spotify.com/v1/audiobooks/%s";
+static const char *spotify_audiobook_chapters_uri   = "https://api.spotify.com/v1/audiobooks/%s/chapters";
+static const char *spotify_chapter_uri              = "https://api.spotify.com/v1/chapters/%s";
 
 
 static enum spotify_item_type
@@ -192,6 +198,14 @@ parse_type_from_uri(const char *uri)
   else if (strncasecmp(uri, "spotify:episode:", strlen("spotify:episode:")) == 0)
     {
       return SPOTIFY_ITEM_TYPE_EPISODE;
+    }
+  else if (strncasecmp(uri, "spotify:audiobook:", strlen("spotify:audiobook:")) == 0)
+    {
+      return SPOTIFY_ITEM_TYPE_AUDIOBOOK;
+    }
+  else if (strncasecmp(uri, "spotify:chapter:", strlen("spotify:chapter:")) == 0)
+    {
+      return SPOTIFY_ITEM_TYPE_CHAPTER;
     }
   else if (strncasecmp(uri, "spotify:", strlen("spotify:")) == 0 && strstr(uri, "playlist:"))
     {
@@ -323,14 +337,14 @@ credentials_token_info(struct spotifywebapi_access_token *info)
   memset(info, 0, sizeof(struct spotifywebapi_access_token));
 
   CHECK_ERR(L_SPOTIFY, pthread_mutex_lock(&spotify_credentials_lock));
-  
+
   if (spotify_credentials.token_time_requested > 0)
     info->expires_in = spotify_credentials.token_expires_in - difftime(time(NULL), spotify_credentials.token_time_requested);
   else
     info->expires_in = 0;
 
   info->token = safe_strdup(spotify_credentials.access_token);
-  
+
   CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&spotify_credentials_lock));
 }
 
@@ -1011,6 +1025,74 @@ parse_metadata_episode(json_object *jsonepisode, struct spotify_track *episode, 
 }
 
 /*
+ * Parse metadata for an audiobook from the Spotify Web API JSON response.
+ * Reuses struct spotify_album since audiobooks have similar metadata to shows.
+ *
+ * API endpoint: https://api.spotify.com/v1/audiobooks/{id}
+ */
+static void
+parse_metadata_audiobook(json_object *jsonaudiobook, struct spotify_album *audiobook)
+{
+  json_object *jsonauthors;
+
+  memset(audiobook, 0, sizeof(struct spotify_album));
+
+  audiobook->name = jparse_str_from_obj(jsonaudiobook, "name");
+  audiobook->uri = jparse_str_from_obj(jsonaudiobook, "uri");
+  audiobook->id = jparse_str_from_obj(jsonaudiobook, "id");
+  audiobook->type = jparse_str_from_obj(jsonaudiobook, "type");
+
+  // Audiobooks use "authors" array instead of "publisher"
+  if (json_object_object_get_ex(jsonaudiobook, "authors", &jsonauthors))
+    audiobook->artist = jparse_str_from_array(jsonauthors, 0, "name");
+
+  audiobook->label = jparse_str_from_obj(jsonaudiobook, "publisher");
+}
+
+/*
+ * Parse metadata for an audiobook chapter from the Spotify Web API JSON response.
+ * Reuses struct spotify_track since chapters have similar metadata to episodes.
+ *
+ * API endpoint: https://api.spotify.com/v1/audiobooks/{id}/chapters
+ */
+static void
+parse_metadata_chapter(json_object *jsonchapter, struct spotify_track *chapter, int max_w)
+{
+  json_object *jsonaudiobook;
+
+  memset(chapter, 0, sizeof(struct spotify_track));
+
+  if (json_object_object_get_ex(jsonchapter, "audiobook", &jsonaudiobook))
+    {
+      chapter->album = jparse_str_from_obj(jsonaudiobook, "name");
+      chapter->artwork_url = get_album_image(jsonaudiobook, max_w);
+    }
+
+  chapter->name = jparse_str_from_obj(jsonchapter, "name");
+  chapter->uri = jparse_str_from_obj(jsonchapter, "uri");
+  chapter->id = jparse_str_from_obj(jsonchapter, "id");
+  chapter->type = jparse_str_from_obj(jsonchapter, "type");
+  chapter->duration_ms = jparse_int_from_obj(jsonchapter, "duration_ms");
+
+  // Spotify chapter_number is 0-based, convert to 1-based to match track_number convention
+  chapter->track_number = jparse_int_from_obj(jsonchapter, "chapter_number") + 1;
+
+  chapter->release_date = jparse_str_from_obj(jsonchapter, "release_date");
+  chapter->release_date_precision = jparse_str_from_obj(jsonchapter, "release_date_precision");
+  if (chapter->release_date_precision && strcmp(chapter->release_date_precision, "day") == 0)
+    chapter->release_date_time = jparse_time_from_obj(jsonchapter, "release_date");
+  chapter->release_year = get_year_from_date(chapter->release_date);
+  chapter->mtime = chapter->release_date_time;
+
+  // "is_playable" is only returned for a request with a market parameter, default to true if it is not in the response
+  chapter->is_playable = true;
+  if (json_object_object_get_ex(jsonchapter, "is_playable", NULL))
+    {
+      chapter->is_playable = jparse_bool_from_obj(jsonchapter, "is_playable");
+    }
+}
+
+/*
  * Creates a new string for the playlist API endpoint for the given playist-uri.
  * The returned string needs to be freed by the caller.
  *
@@ -1159,6 +1241,82 @@ get_episode_endpoint_uri(const char *uri)
   return endpoint_uri;
 }
 
+static char *
+get_audiobook_endpoint_uri(const char *uri)
+{
+  char *endpoint_uri = NULL;
+  char *id = NULL;
+  int ret;
+
+  ret = get_id_from_uri(uri, &id);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_SPOTIFY, "Error extracting id from audiobook uri '%s'\n", uri);
+      goto out;
+    }
+
+  endpoint_uri = safe_asprintf(spotify_audiobook_uri, id);
+
+ out:
+  free(id);
+  return endpoint_uri;
+}
+
+static char *
+get_audiobook_chapters_endpoint_uri(const char *uri)
+{
+  char *endpoint_uri = NULL;
+  char *id = NULL;
+  int ret;
+
+  ret = get_id_from_uri(uri, &id);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_SPOTIFY, "Error extracting id from audiobook uri '%s'\n", uri);
+      goto out;
+    }
+
+  endpoint_uri = safe_asprintf(spotify_audiobook_chapters_uri, id);
+
+ out:
+  free(id);
+  return endpoint_uri;
+}
+
+static char *
+get_chapter_endpoint_uri(const char *uri)
+{
+  char *endpoint_uri = NULL;
+  char *id = NULL;
+  int ret;
+
+  ret = get_id_from_uri(uri, &id);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_SPOTIFY, "Error extracting id from chapter uri '%s'\n", uri);
+      goto out;
+    }
+
+  endpoint_uri = safe_asprintf(spotify_chapter_uri, id);
+
+ out:
+  free(id);
+  return endpoint_uri;
+}
+
+static json_object *
+request_chapter(const char *path)
+{
+  char *endpoint_uri;
+  json_object *response;
+
+  endpoint_uri = get_chapter_endpoint_uri(path);
+  response = request_endpoint_with_token_refresh(endpoint_uri);
+  free(endpoint_uri);
+
+  return response;
+}
+
 static json_object *
 request_track(const char *path)
 {
@@ -1254,6 +1412,50 @@ queue_add_track(int *count, int *new_item_id, const char *uri, int position, cha
   DPRINTF(E_DBG, L_SPOTIFY, "Got track: '%s' (%s) \n", track.name, track.uri);
 
   map_track_to_queueitem(&item, &track, NULL);
+
+  ret = db_queue_add_start(&queue_add_info, position);
+  if (ret < 0)
+    goto error;
+
+  ret = db_queue_add_next(&queue_add_info, &item);
+  ret = db_queue_add_end(&queue_add_info, reshuffle, item_id, ret);
+  if (ret < 0)
+    goto error;
+
+  if (count)
+    *count = queue_add_info.count;
+  if (new_item_id)
+    *new_item_id = queue_add_info.new_item_id;
+
+  free_queue_item(&item, 1);
+  jparse_free(response);
+  return 0;
+
+ error:
+  free_queue_item(&item, 1);
+  jparse_free(response);
+  return -1;
+}
+
+static int
+queue_add_chapter(int *count, int *new_item_id, const char *uri, int position, char reshuffle, uint32_t item_id)
+{
+  json_object *response = NULL;
+  struct spotify_track chapter;
+  struct db_queue_item item = { 0 };
+  struct db_queue_add_info queue_add_info;
+  int ret;
+
+  response = request_chapter(uri);
+  if (!response)
+    goto error;
+
+  parse_metadata_chapter(response, &chapter, ART_DEFAULT_WIDTH);
+
+  DPRINTF(E_DBG, L_SPOTIFY, "Got chapter: '%s' (%s) \n", chapter.name, chapter.uri);
+
+  map_track_to_queueitem(&item, &chapter, NULL);
+  item.media_kind = MEDIA_KIND_AUDIOBOOK;
 
   ret = db_queue_add_start(&queue_add_info, position);
   if (ret < 0)
@@ -1459,6 +1661,77 @@ queue_add_playlist(int *count, int *new_item_id, const char *uri, int position, 
   return ret;
 }
 
+static int
+queue_add_audiobook_chapters(json_object *item, int index, int total, enum spotify_request_type request_type, void *arg)
+{
+  struct queue_add_album_param *param;
+  struct spotify_track chapter;
+  struct db_queue_item queue_item;
+  int ret;
+
+  param = arg;
+
+  parse_metadata_chapter(item, &chapter, ART_DEFAULT_WIDTH);
+
+  if (!chapter.uri || !chapter.is_playable)
+    {
+      DPRINTF(E_LOG, L_SPOTIFY, "Chapter not available for playback: '%s' (%s)\n", chapter.name, chapter.uri);
+      return -1;
+    }
+
+  map_track_to_queueitem(&queue_item, &chapter, &param->album);
+  queue_item.media_kind = MEDIA_KIND_AUDIOBOOK;
+
+  ret = db_queue_add_next(&param->queue_add_info, &queue_item);
+
+  free_queue_item(&queue_item, 1);
+
+  return ret;
+}
+
+static int
+queue_add_audiobook(int *count, int *new_item_id, const char *uri, int position, char reshuffle, uint32_t item_id)
+{
+  char *audiobook_endpoint_uri = NULL;
+  char *endpoint_uri = NULL;
+  json_object *json_audiobook;
+  struct queue_add_album_param param;
+  int ret;
+
+  audiobook_endpoint_uri = get_audiobook_endpoint_uri(uri);
+  json_audiobook = request_endpoint_with_token_refresh(audiobook_endpoint_uri);
+  if (!json_audiobook)
+    {
+      DPRINTF(E_LOG, L_SPOTIFY, "Could not fetch audiobook '%s'\n", uri);
+      ret = -1;
+      goto out;
+    }
+
+  parse_metadata_audiobook(json_audiobook, &param.album);
+
+  ret = db_queue_add_start(&param.queue_add_info, position);
+  if (ret < 0)
+    goto out;
+
+  endpoint_uri = get_audiobook_chapters_endpoint_uri(uri);
+
+  ret = request_pagingobject_endpoint(endpoint_uri, queue_add_audiobook_chapters, NULL, NULL, true, SPOTIFY_REQUEST_TYPE_DEFAULT, &param);
+
+  ret = db_queue_add_end(&param.queue_add_info, reshuffle, item_id, ret);
+  if (ret < 0)
+    goto out;
+
+  if (count)
+    *count = param.queue_add_info.count;
+
+ out:
+  free(audiobook_endpoint_uri);
+  free(endpoint_uri);
+  jparse_free(json_audiobook);
+
+  return ret;
+}
+
 
 /*
  * Returns the directory id for /spotify:/<artist>/<album>, if the directory (or the parent
@@ -1516,6 +1789,8 @@ map_track_to_mfi(struct media_file_info *mfi, const struct spotify_track *track,
   mfi->data_kind   = DATA_KIND_SPOTIFY;
   if (strcmp(track->type, "episode") == 0)
     mfi->media_kind  = MEDIA_KIND_PODCAST;
+  else if (strcmp(track->type, "chapter") == 0)
+    mfi->media_kind  = MEDIA_KIND_AUDIOBOOK;
   else
     mfi->media_kind  = MEDIA_KIND_MUSIC;
   mfi->type        = strdup("spotify");
@@ -1554,9 +1829,9 @@ map_track_to_mfi(struct media_file_info *mfi, const struct spotify_track *track,
       mfi->compilation = true;
     }
 
-  if (mfi->media_kind == MEDIA_KIND_PODCAST)
+  if (mfi->media_kind == MEDIA_KIND_PODCAST || mfi->media_kind == MEDIA_KIND_AUDIOBOOK)
     {
-      // For podcasts we want the tracks/episodes release date
+      // For podcasts and audiobook chapters we want the tracks/episodes release date
       mfi->date_released = track->release_date_time;
       mfi->year = track->release_year;
     }
@@ -1776,6 +2051,104 @@ scan_saved_shows(enum spotify_request_type request_type)
 }
 
 /*
+ * Add a saved audiobook's chapters to the library
+ */
+static int
+saved_chapters_add(json_object *item, int index, int total, enum spotify_request_type request_type, void *arg)
+{
+  struct spotify_album *audiobook = arg;
+  struct spotify_track chapter;
+  int dir_id;
+
+  DPRINTF(E_DBG, L_SPOTIFY, "saved_chapters_add: %s\n", json_object_to_json_string(item));
+
+  // Map chapter information
+  parse_metadata_chapter(item, &chapter, 0);
+
+  // Get or create the directory structure for this audiobook
+  dir_id = prepare_directories(audiobook->artist, audiobook->name);
+
+  track_add(&chapter, audiobook, NULL, dir_id, request_type);
+
+  return 0;
+}
+
+/*
+ * Add a saved audiobook to the library
+ *
+ * API endpoint: https://api.spotify.com/v1/me/audiobooks
+ */
+static int
+saved_audiobook_add(json_object *item, int index, int total, enum spotify_request_type request_type, void *arg)
+{
+  json_object *jsonaudiobook;
+  struct spotify_album audiobook;
+  char *endpoint_uri;
+
+  DPRINTF(E_DBG, L_SPOTIFY, "saved_audiobook_add: %s\n", json_object_to_json_string(item));
+
+  // The saved audiobooks endpoint wraps each audiobook in an object, but
+  // unlike shows/albums there is no wrapper key - the items ARE the audiobooks
+  // directly according to the Spotify API docs for GET /me/audiobooks.
+  // However, let's check if there's an "audiobook" wrapper first for safety.
+  if (json_object_object_get_ex(item, "audiobook", &jsonaudiobook))
+    {
+      DPRINTF(E_DBG, L_SPOTIFY, "Found 'audiobook' wrapper in saved audiobook item\n");
+    }
+  else
+    {
+      // Items are audiobook objects directly
+      jsonaudiobook = item;
+    }
+
+  // Map audiobook information
+  parse_metadata_audiobook(jsonaudiobook, &audiobook);
+  audiobook.added_at = jparse_str_from_obj(item, "added_at");
+  audiobook.mtime = jparse_time_from_obj(item, "added_at");
+
+  DPRINTF(E_DBG, L_SPOTIFY, "Processing audiobook: '%s' by '%s' (id: %s, uri: %s)\n",
+	  audiobook.name, audiobook.artist, audiobook.id, audiobook.uri);
+
+  if (!audiobook.id || !audiobook.uri)
+    {
+      DPRINTF(E_LOG, L_SPOTIFY, "Skipping audiobook at index %d, missing id or uri\n", index);
+      return -1;
+    }
+
+  // Fetch and iterate over the audiobook's chapters
+  endpoint_uri = safe_asprintf(spotify_audiobook_chapters_uri, audiobook.id);
+  request_pagingobject_endpoint(endpoint_uri, saved_chapters_add, transaction_start, transaction_end, true, request_type, &audiobook);
+  free(endpoint_uri);
+
+  if ((index + 1) >= total || ((index + 1) % 10 == 0))
+    DPRINTF(E_LOG, L_SPOTIFY, "Scanned %d of %d saved audiobooks\n", (index + 1), total);
+
+  return 0;
+}
+
+/*
+ * Thread: library
+ *
+ * Scan users saved audiobooks into the library
+ */
+static int
+scan_saved_audiobooks(enum spotify_request_type request_type)
+{
+  int ret;
+
+  DPRINTF(E_LOG, L_SPOTIFY, "Starting scan of saved audiobooks\n");
+
+  ret = request_pagingobject_endpoint(spotify_audiobooks_uri, saved_audiobook_add, NULL, NULL, true, request_type, NULL);
+
+  if (ret < 0)
+    DPRINTF(E_LOG, L_SPOTIFY, "Error scanning saved audiobooks\n");
+  else
+    DPRINTF(E_LOG, L_SPOTIFY, "Finished scanning saved audiobooks\n");
+
+  return ret;
+}
+
+/*
  * Add a saved playlist's tracks to the library
  */
 static int
@@ -1965,6 +2338,7 @@ scan(enum spotify_request_type request_type)
   spotify_status_get(&sp_status);
   if (sp_status.has_podcast_support)
     scan_saved_shows(request_type);
+  scan_saved_audiobooks(request_type);
 
   scanning = false;
   end = time(NULL);
@@ -2000,6 +2374,16 @@ spotifywebapi_library_queue_item_add(const char *uri, int position, char reshuff
   else if (type == SPOTIFY_ITEM_TYPE_PLAYLIST)
     {
       queue_add_playlist(count, new_item_id, uri, position, reshuffle, item_id);
+      goto out;
+    }
+  else if (type == SPOTIFY_ITEM_TYPE_AUDIOBOOK)
+    {
+      queue_add_audiobook(count, new_item_id, uri, position, reshuffle, item_id);
+      goto out;
+    }
+  else if (type == SPOTIFY_ITEM_TYPE_CHAPTER)
+    {
+      queue_add_chapter(count, new_item_id, uri, position, reshuffle, item_id);
       goto out;
     }
 
@@ -2271,6 +2655,12 @@ spotifywebapi_artwork_url_get(const char *uri, int max_w, int max_h)
       response = request_episode(uri);
       if (response)
 	parse_metadata_episode(response, &track, max_w);
+    }
+  else if (type == SPOTIFY_ITEM_TYPE_CHAPTER)
+    {
+      response = request_chapter(uri);
+      if (response)
+	parse_metadata_chapter(response, &track, max_w);
     }
   else
     {

--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -1787,12 +1787,21 @@ map_track_to_mfi(struct media_file_info *mfi, const struct spotify_track *track,
   mfi->track = track->track_number;
 
   mfi->data_kind   = DATA_KIND_SPOTIFY;
-  if (strcmp(track->type, "episode") == 0)
+  if (!track->type)
+    {
+      DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) has NULL type, defaulting to MUSIC\n", track->name, track->uri);
+      mfi->media_kind  = MEDIA_KIND_MUSIC;
+    }
+  else if (strcmp(track->type, "episode") == 0)
     mfi->media_kind  = MEDIA_KIND_PODCAST;
   else if (strcmp(track->type, "chapter") == 0)
     mfi->media_kind  = MEDIA_KIND_AUDIOBOOK;
   else
-    mfi->media_kind  = MEDIA_KIND_MUSIC;
+    {
+      DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) has unknown type '%s', defaulting to MUSIC\n", track->name, track->uri, track->type);
+      mfi->media_kind  = MEDIA_KIND_MUSIC;
+    }
+  DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' mapped to media_kind=%d (type=%s)\n", track->name, mfi->media_kind, track->type ? track->type : "(null)");
   mfi->type        = strdup("spotify");
   mfi->codectype   = strdup("wav");
   mfi->description = strdup("Spotify audio");
@@ -1853,14 +1862,17 @@ track_add(struct spotify_track *track, struct spotify_album *album, const char *
       return -1;
     }
 
+  DPRINTF(E_DBG, L_SPOTIFY, "track_add: '%s' by '%s' (uri: %s, type: %s, playable: %d)\n",
+	  track->name, track->artist, track->uri, track->type ? track->type : "(null)", track->is_playable);
+
   if (track->linked_from_uri)
     DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) linked from %s\n", track->name, track->uri, track->linked_from_uri);
 
   ret = db_file_ping_bypath(track->uri, track->mtime);
   if (ret == 0 || request_type == SPOTIFY_REQUEST_TYPE_METARESCAN)
     {
-      DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) is new or modified (mtime is %" PRIi64 ")\n",
-	      track->name, track->uri, (int64_t)track->mtime);
+      DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) is new or modified (mtime is %" PRIi64 ", ping returned %d)\n",
+	      track->name, track->uri, (int64_t)track->mtime, ret);
 
       memset(&mfi, 0, sizeof(struct media_file_info));
 
@@ -1871,7 +1883,15 @@ track_add(struct spotify_track *track, struct spotify_album *album, const char *
 
       library_media_save(&mfi);
 
+      DPRINTF(E_DBG, L_SPOTIFY, "Saved track '%s' to db (id=%d, dir_id=%d, media_kind=%d)\n",
+	      track->name, mfi.id, mfi.directory_id, mfi.media_kind);
+
       free_mfi(&mfi, 1);
+    }
+  else
+    {
+      DPRINTF(E_DBG, L_SPOTIFY, "Track '%s' (%s) unchanged, skipping save (ping returned %d)\n",
+	      track->name, track->uri, ret);
     }
 
   if (album && album->uri)
@@ -2065,6 +2085,18 @@ saved_chapters_add(json_object *item, int index, int total, enum spotify_request
   // Map chapter information
   parse_metadata_chapter(item, &chapter, 0);
 
+  DPRINTF(E_DBG, L_SPOTIFY, "Chapter %d/%d: '%s' (uri: %s, type: %s, duration: %dms, playable: %d)\n",
+	  index + 1, total, chapter.name, chapter.uri, chapter.type ? chapter.type : "(null)",
+	  chapter.duration_ms, chapter.is_playable);
+
+  // Ensure type is "chapter" so map_track_to_mfi sets MEDIA_KIND_AUDIOBOOK
+  if (!chapter.type || strcmp(chapter.type, "chapter") != 0)
+    {
+      DPRINTF(E_DBG, L_SPOTIFY, "Overriding chapter type from '%s' to 'chapter' for '%s'\n",
+	      chapter.type ? chapter.type : "(null)", chapter.name);
+      chapter.type = "chapter";
+    }
+
   // Get or create the directory structure for this audiobook
   dir_id = prepare_directories(audiobook->artist, audiobook->name);
 
@@ -2084,6 +2116,7 @@ saved_audiobook_add(json_object *item, int index, int total, enum spotify_reques
   json_object *jsonaudiobook;
   struct spotify_album audiobook;
   char *endpoint_uri;
+  int ret;
 
   DPRINTF(E_DBG, L_SPOTIFY, "saved_audiobook_add: %s\n", json_object_to_json_string(item));
 
@@ -2106,8 +2139,9 @@ saved_audiobook_add(json_object *item, int index, int total, enum spotify_reques
   audiobook.added_at = jparse_str_from_obj(item, "added_at");
   audiobook.mtime = jparse_time_from_obj(item, "added_at");
 
-  DPRINTF(E_DBG, L_SPOTIFY, "Processing audiobook: '%s' by '%s' (id: %s, uri: %s)\n",
-	  audiobook.name, audiobook.artist, audiobook.id, audiobook.uri);
+  DPRINTF(E_DBG, L_SPOTIFY, "Processing audiobook %d/%d: '%s' by '%s' (id: %s, uri: %s, type: %s)\n",
+	  index + 1, total, audiobook.name, audiobook.artist, audiobook.id, audiobook.uri,
+	  audiobook.type ? audiobook.type : "(null)");
 
   if (!audiobook.id || !audiobook.uri)
     {
@@ -2117,11 +2151,13 @@ saved_audiobook_add(json_object *item, int index, int total, enum spotify_reques
 
   // Fetch and iterate over the audiobook's chapters
   endpoint_uri = safe_asprintf(spotify_audiobook_chapters_uri, audiobook.id);
-  request_pagingobject_endpoint(endpoint_uri, saved_chapters_add, transaction_start, transaction_end, true, request_type, &audiobook);
+  ret = request_pagingobject_endpoint(endpoint_uri, saved_chapters_add, transaction_start, transaction_end, true, request_type, &audiobook);
   free(endpoint_uri);
 
+  DPRINTF(E_DBG, L_SPOTIFY, "Audiobook '%s' chapters fetch returned %d\n", audiobook.name, ret);
+
   if ((index + 1) >= total || ((index + 1) % 10 == 0))
-    DPRINTF(E_LOG, L_SPOTIFY, "Scanned %d of %d saved audiobooks\n", (index + 1), total);
+    DPRINTF(E_DBG, L_SPOTIFY, "Scanned %d of %d saved audiobooks\n", (index + 1), total);
 
   return 0;
 }
@@ -2136,14 +2172,14 @@ scan_saved_audiobooks(enum spotify_request_type request_type)
 {
   int ret;
 
-  DPRINTF(E_LOG, L_SPOTIFY, "Starting scan of saved audiobooks\n");
+  DPRINTF(E_DBG, L_SPOTIFY, "Starting scan of saved audiobooks\n");
 
   ret = request_pagingobject_endpoint(spotify_audiobooks_uri, saved_audiobook_add, NULL, NULL, true, request_type, NULL);
 
   if (ret < 0)
     DPRINTF(E_LOG, L_SPOTIFY, "Error scanning saved audiobooks\n");
   else
-    DPRINTF(E_LOG, L_SPOTIFY, "Finished scanning saved audiobooks\n");
+    DPRINTF(E_DBG, L_SPOTIFY, "Finished scanning saved audiobooks\n");
 
   return ret;
 }

--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -2071,13 +2071,21 @@ saved_chapters_add(json_object *item, int index, int total, enum spotify_request
     chapter.type = "chapter";
 
   // If the chapter has no name, or Spotify returned a generic "Track N" style
-  // name, replace it with "Chapter N" which is more appropriate for audiobooks
-  if (!chapter.name || chapter.name[0] == '\0'
-      || strncasecmp(chapter.name, "Track ", strlen("Track ")) == 0)
-    {
-      snprintf(chapter_name, sizeof(chapter_name), "Chapter %d", chapter.track_number);
-      chapter.name = chapter_name;
-    }
+  // name, replace it with "Chapter N" which is more appropriate for audiobooks.
+  // Use sscanf to match exactly "Track <number>" so we don't accidentally
+  // rename a real chapter title that happens to start with "Track".
+  {
+    int dummy;
+    int pos = 0;
+
+    if (!chapter.name || chapter.name[0] == '\0'
+        || (sscanf(chapter.name, "Track %d%n", &dummy, &pos) == 1
+            && pos == (int)strlen(chapter.name)))
+      {
+        snprintf(chapter_name, sizeof(chapter_name), "Chapter %d", chapter.track_number);
+        chapter.name = chapter_name;
+      }
+  }
 
   // Get or create the directory structure for this audiobook
   dir_id = prepare_directories(audiobook->artist, audiobook->name);

--- a/src/library/spotify_webapi.c
+++ b/src/library/spotify_webapi.c
@@ -2060,6 +2060,7 @@ saved_chapters_add(json_object *item, int index, int total, enum spotify_request
 {
   struct spotify_album *audiobook = arg;
   struct spotify_track chapter;
+  char chapter_name[64];
   int dir_id;
 
   // Map chapter information
@@ -2068,6 +2069,14 @@ saved_chapters_add(json_object *item, int index, int total, enum spotify_request
   // Ensure type is "chapter" so map_track_to_mfi sets MEDIA_KIND_AUDIOBOOK
   if (!chapter.type || strcmp(chapter.type, "chapter") != 0)
     chapter.type = "chapter";
+
+  // If there is no chapter name, default to "Chapter N" instead of leaving it
+  // blank (which would result in "Unknown title" or a generic "Track N" label)
+  if (!chapter.name || chapter.name[0] == '\0')
+    {
+      snprintf(chapter_name, sizeof(chapter_name), "Chapter %d", chapter.track_number);
+      chapter.name = chapter_name;
+    }
 
   // Get or create the directory structure for this audiobook
   dir_id = prepare_directories(audiobook->artist, audiobook->name);

--- a/web-src/src/components/ListAudiobooksSpotify.vue
+++ b/web-src/src/components/ListAudiobooksSpotify.vue
@@ -1,0 +1,62 @@
+<template>
+  <list-item
+    v-for="item in items"
+    :key="item.id"
+    :is-item="item.isItem"
+    :image="image(item)"
+    :index="item.index"
+    :lines="[item.name, item.authors?.[0]?.name, item.edition]"
+    @open="open(item)"
+    @open-details="openDetails(item)"
+  />
+  <loader-list-item :load="load" />
+  <modal-dialog-audiobook-spotify
+    :item="selectedItem"
+    :show="showDetailsModal"
+    @close="showDetailsModal = false"
+  />
+</template>
+
+<script setup>
+import ListItem from '@/components/ListItem.vue'
+import LoaderListItem from '@/components/LoaderListItem.vue'
+import ModalDialogAudiobookSpotify from '@/components/ModalDialogAudiobookSpotify.vue'
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useSettingsStore } from '@/stores/settings'
+
+defineProps({
+  items: { required: true, type: Object },
+  load: { default: null, type: Function }
+})
+
+const settingsStore = useSettingsStore()
+
+const router = useRouter()
+
+const selectedItem = ref({})
+const showDetailsModal = ref(false)
+
+const image = (item) => {
+  if (settingsStore.showCoverArtworkInAlbumLists) {
+    return {
+      caption: item.name,
+      url: item.images?.[0]?.url ?? ''
+    }
+  }
+  return null
+}
+
+const open = (item) => {
+  router.push({
+    name: 'audiobook-spotify-album',
+    params: { id: item.id }
+  })
+}
+
+const openDetails = (item) => {
+  selectedItem.value = item
+  showDetailsModal.value = true
+}
+</script>
+

--- a/web-src/src/components/ListChaptersSpotify.vue
+++ b/web-src/src/components/ListChaptersSpotify.vue
@@ -1,0 +1,63 @@
+<template>
+  <list-item
+    v-for="(item, index) in items"
+    :key="item.id"
+    :is-playable="item.is_playable !== false"
+    :lines="[
+      item.name,
+      item.description ? truncate(item.description, 80) : ''
+    ]"
+    @open="open(item, index)"
+    @open-details="openDetails(item)"
+  >
+    <template v-if="item.is_playable === false" #reason>
+      (<span v-text="$t('list.spotify.not-playable-track')" />
+      <span
+        v-if="item.restrictions?.reason"
+        v-text="
+          $t('list.spotify.restriction-reason', {
+            reason: item.restrictions.reason
+          })
+        "
+      />)
+    </template>
+  </list-item>
+  <loader-list-item :load="load" />
+  <modal-dialog-track-spotify
+    :item="selectedItem"
+    :show="showDetailsModal"
+    @close="showDetailsModal = false"
+  />
+</template>
+
+<script setup>
+import ListItem from '@/components/ListItem.vue'
+import LoaderListItem from '@/components/LoaderListItem.vue'
+import ModalDialogTrackSpotify from '@/components/ModalDialogTrackSpotify.vue'
+import queue from '@/api/queue'
+import { ref } from 'vue'
+
+const props = defineProps({
+  contextUri: { default: '', type: String },
+  items: { required: true, type: Object },
+  load: { default: null, type: Function }
+})
+
+const selectedItem = ref({})
+const showDetailsModal = ref(false)
+
+const truncate = (text, length) =>
+  text.length > length ? `${text.substring(0, length)}…` : text
+
+const open = (item, index) => {
+  if (item.is_playable !== false) {
+    queue.playUri(props.contextUri || item.uri, false, index)
+  }
+}
+
+const openDetails = (item) => {
+  selectedItem.value = item
+  showDetailsModal.value = true
+}
+</script>
+

--- a/web-src/src/components/ModalDialogAudiobookSpotify.vue
+++ b/web-src/src/components/ModalDialogAudiobookSpotify.vue
@@ -1,0 +1,52 @@
+<template>
+  <modal-dialog-playable
+    :item="playable"
+    :show="show"
+    @close="$emit('close')"
+  />
+</template>
+
+<script setup>
+import ModalDialogPlayable from '@/components/ModalDialogPlayable.vue'
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+
+const props = defineProps({
+  item: { required: true, type: Object },
+  show: Boolean
+})
+
+const emit = defineEmits(['close'])
+
+const router = useRouter()
+
+const openAuthor = () => {
+  emit('close')
+  router.push({
+    name: 'audiobook-spotify-album',
+    params: { id: props.item.id }
+  })
+}
+
+const playable = computed(() => ({
+  image: props.item.images?.[0]?.url || '',
+  name: props.item.name || '',
+  properties: [
+    {
+      handler: openAuthor,
+      key: 'property.artist',
+      value: props.item.authors?.[0]?.name
+    },
+    {
+      key: 'property.release-date',
+      value: props.item.edition
+    },
+    {
+      key: 'property.type',
+      value: 'audiobook'
+    }
+  ],
+  uri: props.item.uri
+}))
+</script>
+

--- a/web-src/src/components/TabsAudiobooks.vue
+++ b/web-src/src/components/TabsAudiobooks.vue
@@ -4,22 +4,36 @@
 
 <script setup>
 import ControlTabList from '@/components/ControlTabList.vue'
+import { computed } from 'vue'
+import { useServicesStore } from '@/stores/services'
 
-const links = [
-  {
-    icon: 'account-music',
-    key: 'page.audiobooks.tabs.authors',
-    to: { name: 'audiobook-artists' }
-  },
-  {
-    icon: 'album',
-    key: 'page.audiobooks.tabs.audiobooks',
-    to: { name: 'audiobook-albums' }
-  },
-  {
-    icon: 'speaker',
-    key: 'page.audiobooks.tabs.genres',
-    to: { name: 'audiobook-genres' }
+const servicesStore = useServicesStore()
+
+const links = computed(() => {
+  const items = [
+    {
+      icon: 'account-music',
+      key: 'page.audiobooks.tabs.authors',
+      to: { name: 'audiobook-artists' }
+    },
+    {
+      icon: 'album',
+      key: 'page.audiobooks.tabs.audiobooks',
+      to: { name: 'audiobook-albums' }
+    },
+    {
+      icon: 'speaker',
+      key: 'page.audiobooks.tabs.genres',
+      to: { name: 'audiobook-genres' }
+    }
+  ]
+  if (servicesStore.isSpotifyActive) {
+    items.push({
+      icon: 'spotify',
+      key: 'page.audiobooks.tabs.spotify',
+      to: { name: 'audiobook-spotify' }
+    })
   }
-]
+  return items
+})
 </script>

--- a/web-src/src/i18n/de.json
+++ b/web-src/src/i18n/de.json
@@ -29,6 +29,7 @@
     "audiobooks": "{count} Hörbuch|{count} Hörbuch|{count} Hörbücher",
     "authors": "{count} Autor|{count} Autor|{count} Autoren",
     "channels": "{count} canal|{count} canaux",
+    "chapters": "{count} Kapitel|{count} Kapitel|{count} Kapitel",
     "composers": "{count} Komponist|{count} Komponist|{count} Komponisten",
     "genres": "{count} Genre|{count} Genre|{count} Genres",
     "kind": {
@@ -186,7 +187,8 @@
       "tabs": {
         "audiobooks": "Hörbücher",
         "authors": "Autoren",
-        "genres": "Genres"
+        "genres": "Genres",
+        "spotify": "Spotify"
       }
     },
     "composers": {
@@ -268,6 +270,9 @@
       }
     },
     "spotify": {
+      "audiobooks": {
+        "saved-audiobooks": "Gespeicherte Hörbücher"
+      },
       "music": {
         "featured-playlists": "Ausgezeichnete Playlisten",
         "followed-artists": "Verfolgte Künstler",

--- a/web-src/src/i18n/en.json
+++ b/web-src/src/i18n/en.json
@@ -29,6 +29,7 @@
     "audiobooks": "{count} audiobook|{count} audiobook|{count} audiobooks",
     "authors": "{count} author|{count} author|{count} authors",
     "channels": "{count} channel|{count} channels",
+    "chapters": "{count} chapter|{count} chapter|{count} chapters",
     "composers": "{count} composer|{count} composer|{count} composers",
     "genres": "{count} genre|{count} genre|{count} genres",
     "kind": {
@@ -186,7 +187,8 @@
       "tabs": {
         "audiobooks": "Audiobooks",
         "authors": "Authors",
-        "genres": "Genres"
+        "genres": "Genres",
+        "spotify": "Spotify"
       }
     },
     "composers": {
@@ -268,6 +270,9 @@
       }
     },
     "spotify": {
+      "audiobooks": {
+        "saved-audiobooks": "Saved Audiobooks"
+      },
       "music": {
         "featured-playlists": "Featured Playlists",
         "followed-artists": "Followed Artists",

--- a/web-src/src/i18n/fr.json
+++ b/web-src/src/i18n/fr.json
@@ -29,6 +29,7 @@
     "audiobooks": "{count} livre audio|{count} livre audio|{count} livres audio",
     "authors": "{count} auteur|{count} auteur|{count} auteurs",
     "channels": "{count} canal|{count} canaux",
+    "chapters": "{count} chapitre|{count} chapitre|{count} chapitres",
     "composers": "{count} compositeur|{count} compositeur|{count} compositeurs",
     "genres": "{count} genre|{count} genre|{count} genres",
     "kind": {
@@ -186,7 +187,8 @@
       "tabs": {
         "audiobooks": "Livres audio",
         "authors": "Auteurs",
-        "genres": "Genres"
+        "genres": "Genres",
+        "spotify": "Spotify"
       }
     },
     "composers": {
@@ -268,6 +270,9 @@
       }
     },
     "spotify": {
+      "audiobooks": {
+        "saved-audiobooks": "Livres audio enregistrés"
+      },
       "music": {
         "featured-playlists": "Listes de lecture en vedette",
         "followed-artists": "Artistes suivis",

--- a/web-src/src/i18n/zh-CN.json
+++ b/web-src/src/i18n/zh-CN.json
@@ -29,6 +29,7 @@
     "audiobooks": "{count} 个有声读物|{count} 个有声读物",
     "authors": "{count} 位作者|{count} 位作者",
     "channels": "{count} canal|{count} canaux",
+    "chapters": "{count} 个章节|{count} 个章节",
     "composers": "{count} 位作曲家|{count} 位作曲家",
     "genres": "{count} 个流派|{count} 个流派",
     "kind": {
@@ -186,7 +187,8 @@
       "tabs": {
         "audiobooks": "有声读物",
         "authors": "作者",
-        "genres": "流派"
+        "genres": "流派",
+        "spotify": "Spotify"
       }
     },
     "composers": {
@@ -268,6 +270,9 @@
       }
     },
     "spotify": {
+      "audiobooks": {
+        "saved-audiobooks": "已保存的有声读物"
+      },
       "music": {
         "featured-playlists": "特色列表",
         "followed-artists": "关注的艺人",

--- a/web-src/src/i18n/zh-TW.json
+++ b/web-src/src/i18n/zh-TW.json
@@ -29,6 +29,7 @@
     "audiobooks": "{count} 個有聲書|{count} 個有聲書",
     "authors": "{count} 位作者|{count} 位作者",
     "channels": "{count} 信道|{count} 信道",
+    "chapters": "{count} 個章節|{count} 個章節",
     "composers": "{count} 位作曲家|{count} 位作曲家",
     "genres": "{count} 個音樂類型|{count} 個音樂類型",
     "kind": {
@@ -186,7 +187,8 @@
       "tabs": {
         "audiobooks": "有聲書",
         "authors": "作者",
-        "genres": "音樂類型"
+        "genres": "音樂類型",
+        "spotify": "Spotify"
       }
     },
     "composers": {
@@ -268,6 +270,9 @@
       }
     },
     "spotify": {
+      "audiobooks": {
+        "saved-audiobooks": "已儲存的有聲書"
+      },
       "music": {
         "featured-playlists": "特色列表",
         "followed-artists": "關注的藝人",

--- a/web-src/src/pages/PageAudiobookAlbumSpotify.vue
+++ b/web-src/src/pages/PageAudiobookAlbumSpotify.vue
@@ -1,0 +1,82 @@
+<template>
+  <content-with-hero>
+    <template #heading>
+      <pane-hero :content="heading" />
+    </template>
+    <template #image>
+      <control-image
+        :url="audiobook.images?.[0]?.url ?? ''"
+        :caption="audiobook.name"
+        class="is-medium"
+        @click="openDetails"
+      />
+    </template>
+    <template #content>
+      <list-chapters-spotify
+        :items="chapters"
+        :context-uri="audiobook.uri"
+      />
+    </template>
+  </content-with-hero>
+  <modal-dialog-audiobook-spotify
+    :item="audiobook"
+    :show="showDetailsModal"
+    @close="showDetailsModal = false"
+  />
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import ContentWithHero from '@/templates/ContentWithHero.vue'
+import ControlImage from '@/components/ControlImage.vue'
+import ListChaptersSpotify from '@/components/ListChaptersSpotify.vue'
+import ModalDialogAudiobookSpotify from '@/components/ModalDialogAudiobookSpotify.vue'
+import PaneHero from '@/components/PaneHero.vue'
+import queue from '@/api/queue'
+import services from '@/api/services'
+import { useI18n } from 'vue-i18n'
+
+const route = useRoute()
+const { t } = useI18n()
+
+const audiobook = ref({ authors: [{}], chapters: {} })
+const showDetailsModal = ref(false)
+
+const openDetails = () => {
+  showDetailsModal.value = true
+}
+
+const play = () => {
+  showDetailsModal.value = false
+  queue.playUri(audiobook.value.uri, false)
+}
+
+const heading = computed(() => ({
+  actions: [
+    { handler: play, icon: 'play', key: 'actions.play' },
+    { handler: openDetails, icon: 'dots-horizontal' }
+  ],
+  count: t('data.chapters', {
+    count: audiobook.value.chapters?.total ?? 0
+  }),
+  subtitle: audiobook.value.authors?.[0]?.name,
+  title: audiobook.value.name
+}))
+
+const chapters = computed(() => {
+  if (audiobook.value.chapters?.total) {
+    return audiobook.value.chapters.items
+  }
+  return []
+})
+
+onMounted(async () => {
+  const { api, configuration } = await services.spotify.get()
+  audiobook.value = await api.audiobooks.get(
+    route.params.id,
+    configuration.webapi_country
+  )
+})
+</script>
+

--- a/web-src/src/pages/PageAudiobookSpotify.vue
+++ b/web-src/src/pages/PageAudiobookSpotify.vue
@@ -1,0 +1,47 @@
+<template>
+  <tabs-audiobooks />
+  <content-with-heading v-if="audiobooks.length">
+    <template #heading>
+      <pane-title
+        :content="{ title: $t('page.spotify.audiobooks.saved-audiobooks') }"
+      />
+    </template>
+    <template #content>
+      <list-audiobooks-spotify :items="audiobooks" />
+    </template>
+    <template #footer>
+      <router-link
+        :to="{ name: 'audiobook-spotify-saved' }"
+        class="button is-small is-rounded"
+      >
+        {{ $t('actions.show-more') }}
+      </router-link>
+    </template>
+  </content-with-heading>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import ContentWithHeading from '@/templates/ContentWithHeading.vue'
+import ListAudiobooksSpotify from '@/components/ListAudiobooksSpotify.vue'
+import PaneTitle from '@/components/PaneTitle.vue'
+import TabsAudiobooks from '@/components/TabsAudiobooks.vue'
+import services from '@/api/services'
+
+const PAGE_SIZE = 3
+
+const audiobooks = ref([])
+
+onMounted(async () => {
+  try {
+    const { api } = await services.spotify.get()
+    const savedAudiobooks = await api.currentUser.audiobooks.savedAudiobooks(
+      PAGE_SIZE
+    )
+    audiobooks.value = savedAudiobooks.items.map((item) => item.audiobook ?? item)
+  } catch {
+    audiobooks.value = []
+  }
+})
+</script>
+

--- a/web-src/src/pages/PageAudiobookSpotifySavedAudiobooks.vue
+++ b/web-src/src/pages/PageAudiobookSpotifySavedAudiobooks.vue
@@ -1,0 +1,69 @@
+<template>
+  <tabs-audiobooks />
+  <content-with-heading>
+    <template #heading>
+      <pane-title :content="heading" />
+    </template>
+    <template #content>
+      <list-audiobooks-spotify :items="audiobooks" :load="load" />
+    </template>
+  </content-with-heading>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import ContentWithHeading from '@/templates/ContentWithHeading.vue'
+import ListAudiobooksSpotify from '@/components/ListAudiobooksSpotify.vue'
+import PaneTitle from '@/components/PaneTitle.vue'
+import TabsAudiobooks from '@/components/TabsAudiobooks.vue'
+import services from '@/api/services'
+import { useI18n } from 'vue-i18n'
+
+const PAGE_SIZE = 50
+
+const { t } = useI18n()
+
+const audiobooks = ref([])
+const offset = ref(0)
+const total = ref(0)
+
+const heading = computed(() => ({
+  subtitle: [{ count: total.value, key: 'data.audiobooks' }],
+  title: t('page.spotify.audiobooks.saved-audiobooks')
+}))
+
+const appendAudiobooks = (data) => {
+  const items = data.items.map((item) => item.audiobook ?? item)
+  audiobooks.value = audiobooks.value.concat(items)
+  total.value = data.total
+  offset.value += data.limit
+}
+
+const load = async ({ loaded }) => {
+  try {
+    const { api } = await services.spotify.get()
+    const data = await api.currentUser.audiobooks.savedAudiobooks(
+      PAGE_SIZE,
+      offset.value
+    )
+    appendAudiobooks(data)
+    loaded(data.items.length, PAGE_SIZE)
+  } catch {
+    loaded(0, PAGE_SIZE)
+  }
+}
+
+onMounted(async () => {
+  try {
+    const { api } = await services.spotify.get()
+    const data = await api.currentUser.audiobooks.savedAudiobooks(
+      PAGE_SIZE,
+      0
+    )
+    appendAudiobooks(data)
+  } catch {
+    // User may not have the required scope
+  }
+})
+</script>
+

--- a/web-src/src/pages/PageSearchSpotify.vue
+++ b/web-src/src/pages/PageSearchSpotify.vue
@@ -19,6 +19,7 @@ import { computed, onMounted, ref } from 'vue'
 import ContentWithSearch from '@/templates/ContentWithSearch.vue'
 import ListAlbumsSpotify from '@/components/ListAlbumsSpotify.vue'
 import ListArtistsSpotify from '@/components/ListArtistsSpotify.vue'
+import ListAudiobooksSpotify from '@/components/ListAudiobooksSpotify.vue'
 import ListPlaylistsSpotify from '@/components/ListPlaylistsSpotify.vue'
 import ListTracksSpotify from '@/components/ListTracksSpotify.vue'
 import services from '@/api/services'
@@ -27,7 +28,7 @@ import { useSearchStore } from '@/stores/search'
 
 const PAGE_SIZE = 3
 const PAGE_SIZE_EXPANDED = 50
-const SEARCH_TYPES = ['track', 'artist', 'album', 'playlist']
+const SEARCH_TYPES = ['track', 'artist', 'album', 'playlist', 'audiobook']
 
 const searchStore = useSearchStore()
 const router = useRouter()
@@ -39,6 +40,7 @@ const types = ref([...SEARCH_TYPES])
 const components = {
   album: ListAlbumsSpotify,
   artist: ListArtistsSpotify,
+  audiobook: ListAudiobooksSpotify,
   playlist: ListPlaylistsSpotify,
   track: ListTracksSpotify
 }

--- a/web-src/src/router/index.js
+++ b/web-src/src/router/index.js
@@ -8,10 +8,13 @@ import PageArtistSpotify from '@/pages/PageArtistSpotify.vue'
 import PageArtistTracks from '@/pages/PageArtistTracks.vue'
 import PageArtists from '@/pages/PageArtists.vue'
 import PageAudiobookAlbum from '@/pages/PageAudiobookAlbum.vue'
+import PageAudiobookAlbumSpotify from '@/pages/PageAudiobookAlbumSpotify.vue'
 import PageAudiobookAlbums from '@/pages/PageAudiobookAlbums.vue'
 import PageAudiobookArtist from '@/pages/PageAudiobookArtist.vue'
 import PageAudiobookArtists from '@/pages/PageAudiobookArtists.vue'
 import PageAudiobookGenres from '@/pages/PageAudiobookGenres.vue'
+import PageAudiobookSpotify from '@/pages/PageAudiobookSpotify.vue'
+import PageAudiobookSpotifySavedAudiobooks from '@/pages/PageAudiobookSpotifySavedAudiobooks.vue'
 import PageComposerAlbums from '@/pages/PageComposerAlbums.vue'
 import PageComposerTracks from '@/pages/PageComposerTracks.vue'
 import PageComposers from '@/pages/PageComposers.vue'
@@ -104,6 +107,21 @@ export const router = createRouter({
       component: PageAudiobookGenres,
       name: 'audiobook-genres',
       path: '/audiobook/genres'
+    },
+    {
+      component: PageAudiobookSpotify,
+      name: 'audiobook-spotify',
+      path: '/audiobook/spotify'
+    },
+    {
+      component: PageAudiobookAlbumSpotify,
+      name: 'audiobook-spotify-album',
+      path: '/audiobook/spotify/albums/:id'
+    },
+    {
+      component: PageAudiobookSpotifySavedAudiobooks,
+      name: 'audiobook-spotify-saved',
+      path: '/audiobook/spotify/saved-audiobooks'
     },
     {
       name: 'audiobooks',


### PR DESCRIPTION
Add true spotify audiobook supports. Add audiobook to the media library database by updating c code. 
Update the UI, to add views for spotify audiobooks, using the SDK. Add new tab for spotify stream.

Some things of note. 
- Audiobooks do not map to ID3 metadata. There are no genre data, author and compose do not map completely author and nariator. 
- There is a workaround, for audiobooks sometimes being seen as podcasts. 
- Only tested with account that does have audiobook support. 
- AI has been used to make this PR. 

Fixes https://github.com/owntone/owntone-server/issues/1900.